### PR TITLE
Add race time tracking

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -12,6 +12,7 @@ import 'features/stopwatch/presentation/screens/stopwatch_screen.dart';
 import 'features/stopwatch/presentation/screens/interval_timer_screen.dart';
 import 'features/pb/presentation/screens/pb_screen.dart';
 import 'features/profiles/presentation/screens/profiles_screen.dart';
+import 'features/race/presentation/screens/race_times_screen.dart';
 import 'features/analytics/presentation/screens/analytics_screen.dart';
 import 'features/dryland/presentation/screens/dryland_screen.dart';
 import 'features/settings/presentation/screens/sync_settings_screen.dart';
@@ -33,6 +34,10 @@ final _router = GoRouter(
         GoRoute(
           path: '/analytics',
           builder: (context, state) => const AnalyticsScreen(),
+        ),
+        GoRoute(
+          path: '/races',
+          builder: (context, state) => const RaceTimesScreen(),
         ),
         GoRoute(
           path: '/pb',

--- a/lib/app/adaptive_shell.dart
+++ b/lib/app/adaptive_shell.dart
@@ -33,6 +33,7 @@ const appDestinations = [
     icon: Icons.list_alt_outlined,
   ),
   AppDestination(path: '/analytics', label: 'Analytics', icon: Icons.bar_chart),
+  AppDestination(path: '/races', label: 'Races', icon: Icons.flag_outlined),
   AppDestination(path: '/pb', label: 'PBs', icon: Icons.emoji_events_outlined),
   AppDestination(
     path: '/dryland',

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -10,7 +10,7 @@ const List<String> kStrokes = [
 const List<int> kStandardDistances = [25, 50, 100, 200, 400, 800, 1500];
 
 const String kAppName = 'repSwim';
-const int kDbVersion = 7;
+const int kDbVersion = 8;
 const String kDefaultProfileId = 'local-default-profile';
 const String kDefaultProfileName = 'Default Swimmer';
 const String kSelectedProfileIdSetting = 'selected_profile_id';

--- a/lib/core/sync/sync_payloads.dart
+++ b/lib/core/sync/sync_payloads.dart
@@ -1,6 +1,7 @@
 import '../../features/dryland/domain/entities/dryland_workout.dart';
 import '../../features/dryland/domain/entities/exercise.dart';
 import '../../features/profiles/domain/entities/swimmer_profile.dart';
+import '../../features/race/domain/entities/race_time.dart';
 import '../../features/swim/domain/entities/lap.dart';
 import '../../features/swim/domain/entities/swim_session.dart';
 import '../../features/templates/domain/entities/dryland_routine_template.dart';
@@ -60,6 +61,24 @@ Map<String, Object?> swimmerProfilePayload(SwimmerProfile profile) {
     'notes': profile.notes,
     'createdAt': profile.createdAt.toUtc().millisecondsSinceEpoch,
     'updatedAt': profile.updatedAt.toUtc().millisecondsSinceEpoch,
+  };
+}
+
+Map<String, Object?> raceTimePayload(RaceTime raceTime) {
+  return {
+    'id': raceTime.id,
+    'profileId': raceTime.profileId,
+    'raceName': raceTime.raceName,
+    'eventDate': raceTime.eventDate.toUtc().millisecondsSinceEpoch,
+    'distance': raceTime.distance,
+    'stroke': raceTime.stroke,
+    'courseType': raceTime.course.name,
+    'timeCentiseconds': raceTime.timeCentiseconds,
+    'notes': raceTime.notes,
+    'placement': raceTime.placement,
+    'location': raceTime.location,
+    'createdAt': raceTime.createdAt.toUtc().millisecondsSinceEpoch,
+    'updatedAt': raceTime.updatedAt.toUtc().millisecondsSinceEpoch,
   };
 }
 

--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -124,6 +124,7 @@ class AppDatabase {
     await _createSyncQueueTable(db);
     await _createTrainingTemplateTables(db);
     await _createAppSettingsTable(db);
+    await _createRaceTimesTable(db);
   }
 
   Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
@@ -166,6 +167,9 @@ class AppDatabase {
         definition: 'INTEGER NOT NULL DEFAULT 0',
       );
       await db.execute('UPDATE sync_queue SET sequence = rowid');
+    }
+    if (oldVersion < 8) {
+      await _createRaceTimesTable(db);
     }
   }
 
@@ -279,6 +283,34 @@ class AppDatabase {
         value TEXT NOT NULL,
         updated_at INTEGER NOT NULL
       )
+    ''');
+  }
+
+  Future<void> _createRaceTimesTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS race_times (
+        id TEXT PRIMARY KEY,
+        profile_id TEXT NOT NULL,
+        race_name TEXT NOT NULL,
+        event_date INTEGER NOT NULL,
+        distance INTEGER NOT NULL,
+        stroke TEXT NOT NULL,
+        course_type TEXT NOT NULL,
+        time_centiseconds INTEGER NOT NULL,
+        notes TEXT,
+        placement INTEGER,
+        location TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    ''');
+    await db.execute('''
+      CREATE INDEX IF NOT EXISTS idx_race_times_profile_event
+      ON race_times(profile_id, event_date DESC)
+    ''');
+    await db.execute('''
+      CREATE INDEX IF NOT EXISTS idx_race_times_profile_course_event
+      ON race_times(profile_id, stroke, distance, course_type)
     ''');
   }
 

--- a/lib/database/daos/race_time_dao.dart
+++ b/lib/database/daos/race_time_dao.dart
@@ -1,0 +1,84 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../../features/race/domain/entities/race_time.dart';
+import '../app_database.dart';
+
+class RaceTimeDao {
+  const RaceTimeDao(this._db);
+
+  final AppDatabase _db;
+
+  Future<List<RaceTime>> getAll(String profileId) async {
+    final db = await _db.database;
+    final rows = await db.query(
+      'race_times',
+      where: 'profile_id = ?',
+      whereArgs: [profileId],
+      orderBy: 'event_date DESC, race_name COLLATE NOCASE ASC',
+    );
+    return rows.map(_fromRow).toList();
+  }
+
+  Future<void> insertOrUpdate(RaceTime raceTime) async {
+    final db = await _db.database;
+    await db.insert(
+      'race_times',
+      _toRow(raceTime),
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  Future<void> delete(String id, String profileId) async {
+    final db = await _db.database;
+    await db.delete(
+      'race_times',
+      where: 'id = ? AND profile_id = ?',
+      whereArgs: [id, profileId],
+    );
+  }
+
+  Map<String, Object?> _toRow(RaceTime raceTime) {
+    return {
+      'id': raceTime.id,
+      'profile_id': raceTime.profileId,
+      'race_name': raceTime.raceName,
+      'event_date': raceTime.eventDate.toUtc().millisecondsSinceEpoch,
+      'distance': raceTime.distance,
+      'stroke': raceTime.stroke,
+      'course_type': raceTime.course.name,
+      'time_centiseconds': raceTime.timeCentiseconds,
+      'notes': raceTime.notes,
+      'placement': raceTime.placement,
+      'location': raceTime.location,
+      'created_at': raceTime.createdAt.toUtc().millisecondsSinceEpoch,
+      'updated_at': raceTime.updatedAt.toUtc().millisecondsSinceEpoch,
+    };
+  }
+
+  RaceTime _fromRow(Map<String, Object?> row) {
+    return RaceTime(
+      id: row['id'] as String,
+      profileId: row['profile_id'] as String,
+      raceName: row['race_name'] as String,
+      eventDate: DateTime.fromMillisecondsSinceEpoch(
+        row['event_date'] as int,
+        isUtc: true,
+      ),
+      distance: row['distance'] as int,
+      stroke: row['stroke'] as String,
+      course: RaceCourse.values.byName(row['course_type'] as String),
+      time: Duration(milliseconds: (row['time_centiseconds'] as int) * 10),
+      notes: row['notes'] as String?,
+      placement: row['placement'] as int?,
+      location: row['location'] as String?,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(
+        row['created_at'] as int,
+        isUtc: true,
+      ),
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(
+        row['updated_at'] as int,
+        isUtc: true,
+      ),
+    );
+  }
+}

--- a/lib/features/race/domain/entities/race_time.dart
+++ b/lib/features/race/domain/entities/race_time.dart
@@ -1,0 +1,81 @@
+import '../../../../core/constants/app_constants.dart';
+
+enum RaceCourse {
+  shortCourseMeters('SCM', 'Short course meters'),
+  shortCourseYards('SCY', 'Short course yards'),
+  longCourseMeters('LCM', 'Long course meters');
+
+  const RaceCourse(this.code, this.label);
+
+  final String code;
+  final String label;
+}
+
+class RaceTime {
+  const RaceTime({
+    required this.id,
+    required this.raceName,
+    required this.eventDate,
+    required this.distance,
+    required this.stroke,
+    required this.course,
+    required this.time,
+    required this.createdAt,
+    required this.updatedAt,
+    this.profileId = kDefaultProfileId,
+    this.notes,
+    this.placement,
+    this.location,
+  });
+
+  final String id;
+  final String profileId;
+  final String raceName;
+  final DateTime eventDate;
+  final int distance;
+  final String stroke;
+  final RaceCourse course;
+  final Duration time;
+  final String? notes;
+  final int? placement;
+  final String? location;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  int get timeCentiseconds => (time.inMilliseconds / 10).round();
+
+  RaceTime copyWith({
+    String? id,
+    String? profileId,
+    String? raceName,
+    DateTime? eventDate,
+    int? distance,
+    String? stroke,
+    RaceCourse? course,
+    Duration? time,
+    String? notes,
+    bool clearNotes = false,
+    int? placement,
+    bool clearPlacement = false,
+    String? location,
+    bool clearLocation = false,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return RaceTime(
+      id: id ?? this.id,
+      profileId: profileId ?? this.profileId,
+      raceName: raceName ?? this.raceName,
+      eventDate: eventDate ?? this.eventDate,
+      distance: distance ?? this.distance,
+      stroke: stroke ?? this.stroke,
+      course: course ?? this.course,
+      time: time ?? this.time,
+      notes: clearNotes ? null : notes ?? this.notes,
+      placement: clearPlacement ? null : placement ?? this.placement,
+      location: clearLocation ? null : location ?? this.location,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+}

--- a/lib/features/race/domain/services/race_time_service.dart
+++ b/lib/features/race/domain/services/race_time_service.dart
@@ -1,0 +1,79 @@
+import '../entities/race_time.dart';
+
+enum RaceTimeSort {
+  newest,
+  oldest,
+  fastest,
+  distance,
+}
+
+List<RaceTime> filterRaceTimes(
+  List<RaceTime> raceTimes, {
+  String query = '',
+  int? distance,
+  String? stroke,
+  RaceCourse? course,
+  RaceTimeSort sort = RaceTimeSort.newest,
+}) {
+  final normalizedQuery = query.trim().toLowerCase();
+  final filtered = raceTimes.where((raceTime) {
+    final searchable = [
+      raceTime.raceName,
+      raceTime.stroke,
+      raceTime.course.code,
+      raceTime.course.label,
+      raceTime.location ?? '',
+      raceTime.notes ?? '',
+    ].join(' ').toLowerCase();
+    return (normalizedQuery.isEmpty || searchable.contains(normalizedQuery)) &&
+        (distance == null || raceTime.distance == distance) &&
+        (stroke == null || raceTime.stroke == stroke) &&
+        (course == null || raceTime.course == course);
+  }).toList();
+
+  filtered.sort((a, b) {
+    switch (sort) {
+      case RaceTimeSort.newest:
+        return b.eventDate.compareTo(a.eventDate);
+      case RaceTimeSort.oldest:
+        return a.eventDate.compareTo(b.eventDate);
+      case RaceTimeSort.fastest:
+        final timeComparison = a.time.compareTo(b.time);
+        if (timeComparison != 0) return timeComparison;
+        return b.eventDate.compareTo(a.eventDate);
+      case RaceTimeSort.distance:
+        final distanceComparison = a.distance.compareTo(b.distance);
+        if (distanceComparison != 0) return distanceComparison;
+        return a.time.compareTo(b.time);
+    }
+  });
+  return filtered;
+}
+
+List<RaceTime> bestRaceTimesByEventCourse(List<RaceTime> raceTimes) {
+  final bestByKey = <String, RaceTime>{};
+  for (final raceTime in raceTimes) {
+    final key = [
+      raceTime.profileId,
+      raceTime.stroke,
+      raceTime.distance,
+      raceTime.course.name,
+    ].join('|');
+    final existing = bestByKey[key];
+    if (existing == null ||
+        raceTime.time < existing.time ||
+        (raceTime.time == existing.time &&
+            raceTime.eventDate.isBefore(existing.eventDate))) {
+      bestByKey[key] = raceTime;
+    }
+  }
+  final best = bestByKey.values.toList()
+    ..sort((a, b) {
+      final strokeComparison = a.stroke.compareTo(b.stroke);
+      if (strokeComparison != 0) return strokeComparison;
+      final distanceComparison = a.distance.compareTo(b.distance);
+      if (distanceComparison != 0) return distanceComparison;
+      return a.course.code.compareTo(b.course.code);
+    });
+  return best;
+}

--- a/lib/features/race/presentation/providers/race_time_providers.dart
+++ b/lib/features/race/presentation/providers/race_time_providers.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../../core/sync/sync_mode.dart';
+import '../../../../core/sync/sync_payloads.dart';
+import '../../../../core/sync/sync_providers.dart';
+import '../../../../database/app_database.dart';
+import '../../../../database/daos/race_time_dao.dart';
+import '../../../../database/daos/sync_queue_dao.dart';
+import '../../../profiles/presentation/providers/profile_providers.dart';
+import '../../domain/entities/race_time.dart';
+
+const _uuid = Uuid();
+
+final raceTimeDaoProvider = Provider<RaceTimeDao>((ref) {
+  return RaceTimeDao(AppDatabase.instance);
+});
+
+class RaceTimesNotifier extends StateNotifier<AsyncValue<List<RaceTime>>> {
+  RaceTimesNotifier(
+    this._dao,
+    this._profileId, {
+    SyncQueueDao? syncQueueDao,
+    void Function(Object error)? onQueueFailure,
+  })  : _syncQueueDao = syncQueueDao,
+        _onQueueFailure = onQueueFailure,
+        super(const AsyncValue.loading()) {
+    load();
+  }
+
+  final RaceTimeDao _dao;
+  final String _profileId;
+  final SyncQueueDao? _syncQueueDao;
+  final void Function(Object error)? _onQueueFailure;
+
+  Future<void> load() async {
+    state = const AsyncValue.loading();
+    try {
+      state = AsyncValue.data(await _dao.getAll(_profileId));
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  Future<RaceTime> addRaceTime({
+    required String raceName,
+    required DateTime eventDate,
+    required int distance,
+    required String stroke,
+    required RaceCourse course,
+    required Duration time,
+    String? notes,
+    int? placement,
+    String? location,
+  }) async {
+    final now = DateTime.now().toUtc();
+    final raceTime = RaceTime(
+      id: _uuid.v4(),
+      profileId: _profileId,
+      raceName: raceName.trim(),
+      eventDate: eventDate,
+      distance: distance,
+      stroke: stroke,
+      course: course,
+      time: time,
+      notes: _cleanText(notes),
+      placement: placement,
+      location: _cleanText(location),
+      createdAt: now,
+      updatedAt: now,
+    );
+    await _dao.insertOrUpdate(raceTime);
+    await _queueRaceTime(raceTime, operation: SyncOperation.create);
+    await load();
+    return raceTime;
+  }
+
+  Future<void> updateRaceTime(RaceTime raceTime) async {
+    final updated = raceTime.copyWith(
+      raceName: raceTime.raceName.trim(),
+      notes: _cleanText(raceTime.notes),
+      clearNotes: _cleanText(raceTime.notes) == null,
+      location: _cleanText(raceTime.location),
+      clearLocation: _cleanText(raceTime.location) == null,
+      updatedAt: DateTime.now().toUtc(),
+    );
+    await _dao.insertOrUpdate(updated);
+    await _queueRaceTime(updated, operation: SyncOperation.update);
+    await load();
+  }
+
+  Future<void> deleteRaceTime(String id) async {
+    await _dao.delete(id, _profileId);
+    await _queueChange(
+      entityId: id,
+      operation: SyncOperation.delete,
+      payload: deletedEntityPayload(id: id, profileId: _profileId),
+    );
+    await load();
+  }
+
+  Future<void> _queueRaceTime(
+    RaceTime raceTime, {
+    required SyncOperation operation,
+  }) async {
+    await _queueChange(
+      entityId: raceTime.id,
+      operation: operation,
+      payload: raceTimePayload(raceTime),
+    );
+  }
+
+  Future<void> _queueChange({
+    required String entityId,
+    required SyncOperation operation,
+    required Map<String, Object?> payload,
+  }) async {
+    try {
+      await _syncQueueDao?.enqueue(
+        profileId: _profileId,
+        entityType: 'race_time',
+        entityId: entityId,
+        operation: operation,
+        payload: payload,
+      );
+    } catch (error) {
+      _onQueueFailure?.call(error);
+    }
+  }
+}
+
+String? _cleanText(String? value) {
+  final trimmed = value?.trim();
+  return trimmed == null || trimmed.isEmpty ? null : trimmed;
+}
+
+final raceTimesProvider =
+    StateNotifierProvider<RaceTimesNotifier, AsyncValue<List<RaceTime>>>(
+  (ref) => RaceTimesNotifier(
+    ref.read(raceTimeDaoProvider),
+    ref.watch(currentProfileIdProvider),
+    syncQueueDao: ref.read(syncQueueDaoProvider),
+    onQueueFailure: (error) {
+      ref.read(syncQueueFailureProvider.notifier).state = error.toString();
+    },
+  ),
+);

--- a/lib/features/race/presentation/screens/race_times_screen.dart
+++ b/lib/features/race/presentation/screens/race_times_screen.dart
@@ -1,0 +1,798 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../core/constants/app_constants.dart';
+import '../../../../core/utils/duration_utils.dart';
+import '../../../profiles/presentation/providers/profile_providers.dart';
+import '../../domain/entities/race_time.dart';
+import '../../domain/services/race_time_service.dart';
+import '../providers/race_time_providers.dart';
+
+class RaceTimesScreen extends ConsumerStatefulWidget {
+  const RaceTimesScreen({super.key});
+
+  @override
+  ConsumerState<RaceTimesScreen> createState() => _RaceTimesScreenState();
+}
+
+class _RaceTimesScreenState extends ConsumerState<RaceTimesScreen> {
+  final _searchController = TextEditingController();
+  String _query = '';
+  int? _distance;
+  RaceCourse? _course;
+  RaceTimeSort _sort = RaceTimeSort.newest;
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _showRaceDialog({RaceTime? raceTime}) async {
+    final profile = ref.read(currentProfileProvider);
+    final result = await showDialog<RaceTimeFormResult>(
+      context: context,
+      builder: (_) => RaceTimeFormDialog(
+        profileName: profile.displayName,
+        raceTime: raceTime,
+      ),
+    );
+    if (result == null) return;
+
+    if (raceTime == null) {
+      await ref.read(raceTimesProvider.notifier).addRaceTime(
+            raceName: result.raceName,
+            eventDate: result.eventDate,
+            distance: result.distance,
+            stroke: result.stroke,
+            course: result.course,
+            time: result.time,
+            notes: result.notes,
+            placement: result.placement,
+            location: result.location,
+          );
+    } else {
+      await ref.read(raceTimesProvider.notifier).updateRaceTime(
+            raceTime.copyWith(
+              raceName: result.raceName,
+              eventDate: result.eventDate,
+              distance: result.distance,
+              stroke: result.stroke,
+              course: result.course,
+              time: result.time,
+              notes: result.notes,
+              clearNotes: result.notes == null,
+              placement: result.placement,
+              clearPlacement: result.placement == null,
+              location: result.location,
+              clearLocation: result.location == null,
+            ),
+          );
+    }
+  }
+
+  Future<void> _deleteRaceTime(RaceTime raceTime) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Delete race time?'),
+        content: Text('Delete ${raceTime.raceName} ${raceTime.distance}m?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await ref.read(raceTimesProvider.notifier).deleteRaceTime(raceTime.id);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final raceTimesAsync = ref.watch(raceTimesProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Race Times')),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => _showRaceDialog(),
+        icon: const Icon(Icons.add),
+        label: const Text('Add Race'),
+      ),
+      body: raceTimesAsync.when(
+        data: (raceTimes) {
+          final filtered = filterRaceTimes(
+            raceTimes,
+            query: _query,
+            distance: _distance,
+            course: _course,
+            sort: _sort,
+          );
+          return LayoutBuilder(
+            builder: (context, constraints) {
+              final isWide = constraints.maxWidth >= 900;
+              return ListView(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 96),
+                children: [
+                  _RaceFilters(
+                    searchController: _searchController,
+                    onQueryChanged: (value) => setState(() => _query = value),
+                    distance: _distance,
+                    onDistanceChanged: (value) =>
+                        setState(() => _distance = value),
+                    course: _course,
+                    onCourseChanged: (value) => setState(() => _course = value),
+                    sort: _sort,
+                    onSortChanged: (value) => setState(() => _sort = value),
+                  ),
+                  const SizedBox(height: 12),
+                  _RaceSummary(
+                    visibleCount: filtered.length,
+                    totalCount: raceTimes.length,
+                    raceTimes: filtered,
+                  ),
+                  const SizedBox(height: 12),
+                  if (filtered.isEmpty)
+                    const _EmptyRaceTimes()
+                  else if (isWide)
+                    _RaceTimesTable(
+                      raceTimes: filtered,
+                      onEdit: (raceTime) => _showRaceDialog(raceTime: raceTime),
+                      onDelete: _deleteRaceTime,
+                    )
+                  else
+                    for (final raceTime in filtered)
+                      _RaceTimeCard(
+                        raceTime: raceTime,
+                        onEdit: () => _showRaceDialog(raceTime: raceTime),
+                        onDelete: () => _deleteRaceTime(raceTime),
+                      ),
+                ],
+              );
+            },
+          );
+        },
+        loading: () =>
+            const Center(child: CircularProgressIndicator.adaptive()),
+        error: (error, _) => Center(child: Text('Error: $error')),
+      ),
+    );
+  }
+}
+
+class _RaceFilters extends StatelessWidget {
+  const _RaceFilters({
+    required this.searchController,
+    required this.onQueryChanged,
+    required this.distance,
+    required this.onDistanceChanged,
+    required this.course,
+    required this.onCourseChanged,
+    required this.sort,
+    required this.onSortChanged,
+  });
+
+  final TextEditingController searchController;
+  final ValueChanged<String> onQueryChanged;
+  final int? distance;
+  final ValueChanged<int?> onDistanceChanged;
+  final RaceCourse? course;
+  final ValueChanged<RaceCourse?> onCourseChanged;
+  final RaceTimeSort sort;
+  final ValueChanged<RaceTimeSort> onSortChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 12,
+      runSpacing: 12,
+      children: [
+        SizedBox(
+          width: 300,
+          child: TextField(
+            controller: searchController,
+            decoration: const InputDecoration(
+              labelText: 'Search race times',
+              prefixIcon: Icon(Icons.search),
+              border: OutlineInputBorder(),
+            ),
+            onChanged: onQueryChanged,
+          ),
+        ),
+        SizedBox(
+          width: 160,
+          child: DropdownButtonFormField<int?>(
+            isExpanded: true,
+            initialValue: distance,
+            decoration: const InputDecoration(
+              labelText: 'Distance',
+              border: OutlineInputBorder(),
+            ),
+            items: [
+              const DropdownMenuItem<int?>(
+                value: null,
+                child: Text('All'),
+              ),
+              for (final distance in kStandardDistances)
+                DropdownMenuItem<int?>(
+                  value: distance,
+                  child: Text('${distance}m'),
+                ),
+            ],
+            onChanged: onDistanceChanged,
+          ),
+        ),
+        SizedBox(
+          width: 230,
+          child: DropdownButtonFormField<RaceCourse?>(
+            isExpanded: true,
+            initialValue: course,
+            decoration: const InputDecoration(
+              labelText: 'Course',
+              border: OutlineInputBorder(),
+            ),
+            items: [
+              const DropdownMenuItem<RaceCourse?>(
+                value: null,
+                child: Text('All courses'),
+              ),
+              for (final course in RaceCourse.values)
+                DropdownMenuItem<RaceCourse?>(
+                  value: course,
+                  child: Text(
+                    course.label,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+            ],
+            onChanged: onCourseChanged,
+          ),
+        ),
+        SizedBox(
+          width: 180,
+          child: DropdownButtonFormField<RaceTimeSort>(
+            isExpanded: true,
+            initialValue: sort,
+            decoration: const InputDecoration(
+              labelText: 'Sort',
+              border: OutlineInputBorder(),
+            ),
+            items: const [
+              DropdownMenuItem(
+                value: RaceTimeSort.newest,
+                child: Text('Newest'),
+              ),
+              DropdownMenuItem(
+                value: RaceTimeSort.oldest,
+                child: Text('Oldest'),
+              ),
+              DropdownMenuItem(
+                value: RaceTimeSort.fastest,
+                child: Text('Fastest'),
+              ),
+              DropdownMenuItem(
+                value: RaceTimeSort.distance,
+                child: Text('Distance'),
+              ),
+            ],
+            onChanged: (value) {
+              if (value != null) onSortChanged(value);
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _RaceSummary extends StatelessWidget {
+  const _RaceSummary({
+    required this.visibleCount,
+    required this.totalCount,
+    required this.raceTimes,
+  });
+
+  final int visibleCount;
+  final int totalCount;
+  final List<RaceTime> raceTimes;
+
+  @override
+  Widget build(BuildContext context) {
+    final best = bestRaceTimesByEventCourse(raceTimes).length;
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        Chip(label: Text('$visibleCount of $totalCount race times')),
+        Chip(label: Text('$best course-specific bests')),
+      ],
+    );
+  }
+}
+
+class _RaceTimeCard extends StatelessWidget {
+  const _RaceTimeCard({
+    required this.raceTime,
+    required this.onEdit,
+    required this.onDelete,
+  });
+
+  final RaceTime raceTime;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final date = DateFormat('d MMM yyyy').format(raceTime.eventDate);
+    return Card(
+      child: ListTile(
+        leading: CircleAvatar(child: Text(raceTime.course.code)),
+        title: Text('${raceTime.distance}m ${raceTime.stroke}'),
+        subtitle:
+            Text('${raceTime.raceName} - ${raceTime.course.label}\n$date'),
+        isThreeLine: true,
+        trailing: Wrap(
+          spacing: 4,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            Text(
+              DurationUtils.formatDurationWithCentiseconds(raceTime.time),
+              style: const TextStyle(
+                fontFamily: 'monospace',
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            IconButton(
+              tooltip: 'Edit race time',
+              icon: const Icon(Icons.edit_outlined),
+              onPressed: onEdit,
+            ),
+            IconButton(
+              tooltip: 'Delete race time',
+              icon: const Icon(Icons.delete_outline),
+              onPressed: onDelete,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RaceTimesTable extends StatelessWidget {
+  const _RaceTimesTable({
+    required this.raceTimes,
+    required this.onEdit,
+    required this.onDelete,
+  });
+
+  final List<RaceTime> raceTimes;
+  final ValueChanged<RaceTime> onEdit;
+  final ValueChanged<RaceTime> onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: DataTable(
+        columns: const [
+          DataColumn(label: Text('Date')),
+          DataColumn(label: Text('Race')),
+          DataColumn(label: Text('Event')),
+          DataColumn(label: Text('Course')),
+          DataColumn(label: Text('Time')),
+          DataColumn(label: Text('Place')),
+          DataColumn(label: Text('Actions')),
+        ],
+        rows: [
+          for (final raceTime in raceTimes)
+            DataRow(
+              cells: [
+                DataCell(
+                    Text(DateFormat('d MMM yyyy').format(raceTime.eventDate))),
+                DataCell(Text(raceTime.raceName)),
+                DataCell(Text('${raceTime.distance}m ${raceTime.stroke}')),
+                DataCell(Text(raceTime.course.code)),
+                DataCell(Text(DurationUtils.formatDurationWithCentiseconds(
+                  raceTime.time,
+                ))),
+                DataCell(Text(raceTime.placement?.toString() ?? '-')),
+                DataCell(
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IconButton(
+                        tooltip: 'Edit race time',
+                        icon: const Icon(Icons.edit_outlined),
+                        onPressed: () => onEdit(raceTime),
+                      ),
+                      IconButton(
+                        tooltip: 'Delete race time',
+                        icon: const Icon(Icons.delete_outline),
+                        onPressed: () => onDelete(raceTime),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyRaceTimes extends StatelessWidget {
+  const _EmptyRaceTimes();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.symmetric(vertical: 48),
+      child: Center(
+        child: Column(
+          children: [
+            Icon(Icons.flag_outlined, size: 56),
+            SizedBox(height: 12),
+            Text('No race times match your filters'),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class RaceTimeFormResult {
+  const RaceTimeFormResult({
+    required this.raceName,
+    required this.eventDate,
+    required this.distance,
+    required this.stroke,
+    required this.course,
+    required this.time,
+    this.notes,
+    this.placement,
+    this.location,
+  });
+
+  final String raceName;
+  final DateTime eventDate;
+  final int distance;
+  final String stroke;
+  final RaceCourse course;
+  final Duration time;
+  final String? notes;
+  final int? placement;
+  final String? location;
+}
+
+class RaceTimeFormDialog extends StatefulWidget {
+  const RaceTimeFormDialog({
+    super.key,
+    required this.profileName,
+    this.raceTime,
+  });
+
+  final String profileName;
+  final RaceTime? raceTime;
+
+  @override
+  State<RaceTimeFormDialog> createState() => _RaceTimeFormDialogState();
+}
+
+class _RaceTimeFormDialogState extends State<RaceTimeFormDialog> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _raceNameController;
+  late final TextEditingController _distanceController;
+  late final TextEditingController _minutesController;
+  late final TextEditingController _secondsController;
+  late final TextEditingController _centisecondsController;
+  late final TextEditingController _placementController;
+  late final TextEditingController _locationController;
+  late final TextEditingController _notesController;
+  late DateTime _eventDate;
+  late String _stroke;
+  late RaceCourse _course;
+
+  @override
+  void initState() {
+    super.initState();
+    final raceTime = widget.raceTime;
+    _eventDate = raceTime?.eventDate ?? DateTime.now();
+    _stroke = raceTime?.stroke ?? kStrokes.first;
+    _course = raceTime?.course ?? RaceCourse.shortCourseMeters;
+    _raceNameController = TextEditingController(text: raceTime?.raceName ?? '');
+    _distanceController =
+        TextEditingController(text: raceTime?.distance.toString() ?? '100');
+    _minutesController = TextEditingController(
+      text: raceTime == null
+          ? ''
+          : raceTime.time.inMinutes.remainder(60).toString(),
+    );
+    _secondsController = TextEditingController(
+      text: raceTime == null
+          ? ''
+          : raceTime.time.inSeconds.remainder(60).toString(),
+    );
+    _centisecondsController = TextEditingController(
+      text: raceTime == null
+          ? ''
+          : (raceTime.time.inMilliseconds.remainder(1000) ~/ 10).toString(),
+    );
+    _placementController =
+        TextEditingController(text: raceTime?.placement?.toString() ?? '');
+    _locationController = TextEditingController(text: raceTime?.location ?? '');
+    _notesController = TextEditingController(text: raceTime?.notes ?? '');
+  }
+
+  @override
+  void dispose() {
+    _raceNameController.dispose();
+    _distanceController.dispose();
+    _minutesController.dispose();
+    _secondsController.dispose();
+    _centisecondsController.dispose();
+    _placementController.dispose();
+    _locationController.dispose();
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _eventDate,
+      firstDate: DateTime(_eventDate.year - 10),
+      lastDate: DateTime.now().add(const Duration(days: 365)),
+    );
+    if (picked != null) {
+      setState(() => _eventDate = picked);
+    }
+  }
+
+  Duration _enteredTime() {
+    final minutes = int.tryParse(_minutesController.text) ?? 0;
+    final seconds = int.tryParse(_secondsController.text) ?? 0;
+    final centiseconds = int.tryParse(_centisecondsController.text) ?? 0;
+    return Duration(
+      minutes: minutes,
+      seconds: seconds,
+      milliseconds: centiseconds * 10,
+    );
+  }
+
+  void _submit() {
+    if (!_formKey.currentState!.validate()) return;
+    final placement = _placementController.text.trim().isEmpty
+        ? null
+        : int.parse(_placementController.text);
+    Navigator.of(context).pop(
+      RaceTimeFormResult(
+        raceName: _raceNameController.text.trim(),
+        eventDate: _eventDate,
+        distance: int.parse(_distanceController.text),
+        stroke: _stroke,
+        course: _course,
+        time: _enteredTime(),
+        placement: placement,
+        location: _cleanFormText(_locationController.text),
+        notes: _cleanFormText(_notesController.text),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isEditing = widget.raceTime != null;
+    return AlertDialog(
+      title: Text(isEditing ? 'Edit race time' : 'Add race time'),
+      content: SizedBox(
+        width: 520,
+        child: Form(
+          key: _formKey,
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Chip(
+                    avatar: const Icon(Icons.person_outline, size: 16),
+                    label: Text(widget.profileName),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _raceNameController,
+                  decoration: const InputDecoration(labelText: 'Race or meet'),
+                  validator: (value) =>
+                      value == null || value.trim().isEmpty ? 'Required' : null,
+                ),
+                const SizedBox(height: 12),
+                ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: const Icon(Icons.event_outlined),
+                  title: const Text('Event date'),
+                  subtitle: Text(DateFormat('d MMM yyyy').format(_eventDate)),
+                  trailing: const Icon(Icons.edit_calendar_outlined),
+                  onTap: _pickDate,
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextFormField(
+                        controller: _distanceController,
+                        keyboardType: TextInputType.number,
+                        decoration: const InputDecoration(
+                          labelText: 'Distance (m)',
+                        ),
+                        validator: (value) {
+                          final parsed = int.tryParse(value ?? '');
+                          if (parsed == null || parsed <= 0) {
+                            return 'Enter distance';
+                          }
+                          return null;
+                        },
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: DropdownButtonFormField<String>(
+                        isExpanded: true,
+                        initialValue: _stroke,
+                        decoration: const InputDecoration(labelText: 'Stroke'),
+                        items: [
+                          for (final stroke in kStrokes)
+                            DropdownMenuItem(
+                              value: stroke,
+                              child: Text(
+                                stroke,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                        ],
+                        onChanged: (value) {
+                          if (value != null) setState(() => _stroke = value);
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                DropdownButtonFormField<RaceCourse>(
+                  isExpanded: true,
+                  initialValue: _course,
+                  decoration: const InputDecoration(labelText: 'Course type'),
+                  items: [
+                    for (final course in RaceCourse.values)
+                      DropdownMenuItem(
+                        value: course,
+                        child: Text(
+                          course.label,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                  ],
+                  onChanged: (value) {
+                    if (value != null) setState(() => _course = value);
+                  },
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextFormField(
+                        controller: _minutesController,
+                        keyboardType: TextInputType.number,
+                        decoration: const InputDecoration(labelText: 'Min'),
+                        validator: _timePartValidator,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: TextFormField(
+                        controller: _secondsController,
+                        keyboardType: TextInputType.number,
+                        decoration: const InputDecoration(labelText: 'Sec'),
+                        validator: (value) {
+                          final partError = _timePartValidator(value);
+                          if (partError != null) return partError;
+                          final parsed = int.tryParse(value ?? '') ?? 0;
+                          if (parsed > 59) return '0-59';
+                          if (_enteredTime() == Duration.zero) {
+                            return 'Enter time';
+                          }
+                          return null;
+                        },
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: TextFormField(
+                        controller: _centisecondsController,
+                        keyboardType: TextInputType.number,
+                        decoration: const InputDecoration(labelText: 'Csec'),
+                        validator: (value) {
+                          final partError = _timePartValidator(value);
+                          if (partError != null) return partError;
+                          final parsed = int.tryParse(value ?? '') ?? 0;
+                          if (parsed > 99) return '0-99';
+                          return null;
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextFormField(
+                        controller: _placementController,
+                        keyboardType: TextInputType.number,
+                        decoration: const InputDecoration(labelText: 'Place'),
+                        validator: (value) {
+                          if (value == null || value.trim().isEmpty) {
+                            return null;
+                          }
+                          final parsed = int.tryParse(value);
+                          if (parsed == null || parsed <= 0) {
+                            return 'Enter place';
+                          }
+                          return null;
+                        },
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: TextFormField(
+                        controller: _locationController,
+                        decoration:
+                            const InputDecoration(labelText: 'Location'),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _notesController,
+                  decoration: const InputDecoration(labelText: 'Notes'),
+                  maxLines: 2,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _submit,
+          child: Text(isEditing ? 'Save' : 'Add'),
+        ),
+      ],
+    );
+  }
+}
+
+String? _timePartValidator(String? value) {
+  final raw = value ?? '';
+  if (raw.isEmpty) return null;
+  final parsed = int.tryParse(raw);
+  if (parsed == null || parsed < 0) return '>= 0';
+  return null;
+}
+
+String? _cleanFormText(String value) {
+  final trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed;
+}

--- a/test/app/adaptive_shell_test.dart
+++ b/test/app/adaptive_shell_test.dart
@@ -11,6 +11,13 @@ void main() {
       expect(getFormFactor(999), FormFactor.tablet);
       expect(getFormFactor(1000), FormFactor.desktop);
     });
+
+    test('includes race time destination', () {
+      expect(
+        appDestinations.map((destination) => destination.path),
+        contains('/races'),
+      );
+    });
   });
 
   group('AdaptiveShell', () {

--- a/test/core/sync/sync_payloads_test.dart
+++ b/test/core/sync/sync_payloads_test.dart
@@ -5,6 +5,7 @@ import 'package:rep_swim/core/sync/sync_payloads.dart';
 import 'package:rep_swim/features/dryland/domain/entities/dryland_workout.dart';
 import 'package:rep_swim/features/dryland/domain/entities/exercise.dart';
 import 'package:rep_swim/features/profiles/domain/entities/swimmer_profile.dart';
+import 'package:rep_swim/features/race/domain/entities/race_time.dart';
 import 'package:rep_swim/features/swim/domain/entities/lap.dart';
 import 'package:rep_swim/features/swim/domain/entities/swim_session.dart';
 import 'package:rep_swim/features/templates/domain/entities/dryland_routine_template.dart';
@@ -130,6 +131,40 @@ void main() {
         (drylandRoutineTemplatePayload(routine)['exercises'] as List).single,
         containsPair('name', 'Plank'),
       );
+    });
+
+    test('serializes race times with course and centiseconds', () {
+      final raceTime = RaceTime(
+        id: 'race-time-1',
+        profileId: 'profile-1',
+        raceName: 'State Sprint',
+        eventDate: DateTime.utc(2024, 5, 1),
+        distance: 100,
+        stroke: 'Freestyle',
+        course: RaceCourse.longCourseMeters,
+        time: const Duration(minutes: 1, seconds: 2, milliseconds: 340),
+        notes: 'Final',
+        placement: 2,
+        location: 'MSAC',
+        createdAt: DateTime.utc(2024, 5, 1, 1),
+        updatedAt: DateTime.utc(2024, 5, 1, 2),
+      );
+
+      expect(raceTimePayload(raceTime), {
+        'id': 'race-time-1',
+        'profileId': 'profile-1',
+        'raceName': 'State Sprint',
+        'eventDate': 1714521600000,
+        'distance': 100,
+        'stroke': 'Freestyle',
+        'courseType': 'longCourseMeters',
+        'timeCentiseconds': 6234,
+        'notes': 'Final',
+        'placement': 2,
+        'location': 'MSAC',
+        'createdAt': 1714525200000,
+        'updatedAt': 1714528800000,
+      });
     });
   });
 }

--- a/test/database/dao_integration_test.dart
+++ b/test/database/dao_integration_test.dart
@@ -3,12 +3,14 @@ import 'package:rep_swim/core/sync/sync_mode.dart';
 import 'package:rep_swim/database/app_database.dart';
 import 'package:rep_swim/database/daos/dryland_dao.dart';
 import 'package:rep_swim/database/daos/pb_dao.dart';
+import 'package:rep_swim/database/daos/race_time_dao.dart';
 import 'package:rep_swim/database/daos/swim_session_dao.dart';
 import 'package:rep_swim/database/daos/sync_queue_dao.dart';
 import 'package:rep_swim/database/daos/training_template_dao.dart';
 import 'package:rep_swim/features/dryland/domain/entities/dryland_workout.dart';
 import 'package:rep_swim/features/dryland/domain/entities/exercise.dart';
 import 'package:rep_swim/features/pb/domain/entities/personal_best.dart';
+import 'package:rep_swim/features/race/domain/entities/race_time.dart';
 import 'package:rep_swim/features/swim/domain/entities/lap.dart';
 import 'package:rep_swim/features/swim/domain/entities/swim_session.dart';
 import 'package:rep_swim/features/templates/domain/entities/dryland_routine_template.dart';
@@ -268,6 +270,48 @@ void main() {
       expect(pbs, hasLength(1));
       expect(pbs.single.id, 'pb-slow');
       expect(pbs.single.bestTime, const Duration(seconds: 62));
+    });
+
+    test('race times insert, update, delete, and stay profile scoped',
+        () async {
+      final dao = RaceTimeDao(appDb);
+      final race = RaceTime(
+        id: 'race-1',
+        profileId: 'profile-1',
+        raceName: 'Club Champs',
+        eventDate: DateTime.utc(2024, 5, 1),
+        distance: 100,
+        stroke: 'Freestyle',
+        course: RaceCourse.shortCourseMeters,
+        time: const Duration(seconds: 59, milliseconds: 230),
+        placement: 3,
+        createdAt: DateTime.utc(2024, 5, 1),
+        updatedAt: DateTime.utc(2024, 5, 1),
+      );
+      final otherProfileRace = race.copyWith(
+        id: 'race-2',
+        profileId: 'profile-2',
+      );
+
+      await dao.insertOrUpdate(race);
+      await dao.insertOrUpdate(otherProfileRace);
+      await dao.insertOrUpdate(
+        race.copyWith(
+          raceName: 'State Sprint',
+          time: const Duration(seconds: 58, milliseconds: 910),
+        ),
+      );
+
+      final profileOneRaces = await dao.getAll('profile-1');
+      final profileTwoRaces = await dao.getAll('profile-2');
+      expect(profileOneRaces, hasLength(1));
+      expect(profileOneRaces.single.raceName, 'State Sprint');
+      expect(profileOneRaces.single.time.inMilliseconds, 58910);
+      expect(profileTwoRaces.single.id, 'race-2');
+
+      await dao.delete('race-1', 'profile-1');
+      expect(await dao.getAll('profile-1'), isEmpty);
+      expect(await dao.getAll('profile-2'), hasLength(1));
     });
   });
 }

--- a/test/database/migration_test.dart
+++ b/test/database/migration_test.dart
@@ -11,7 +11,7 @@ void main() {
   });
 
   group('database migrations', () {
-    for (final oldVersion in [1, 3, 4, 5]) {
+    for (final oldVersion in [1, 3, 4, 5, 7]) {
       test('upgrades version $oldVersion to current schema', () async {
         final path = p.join(
           Directory.systemTemp.path,
@@ -35,6 +35,7 @@ void main() {
         expect(await _hasTable(db, 'interval_templates'), isTrue);
         expect(await _hasTable(db, 'dryland_routine_templates'), isTrue);
         expect(await _hasTable(db, 'app_settings'), isTrue);
+        expect(await _hasTable(db, 'race_times'), isTrue);
 
         final sessions = await db.query('swim_sessions');
         final pbs = await db.query('personal_bests');
@@ -176,6 +177,20 @@ Future<void> _createOldSchema(Database db, int version) async {
         weight REAL
       )
     ''');
+  }
+  if (version >= 6) {
+    await db.execute('''
+      CREATE TABLE app_settings (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    ''');
+  }
+  if (version >= 7) {
+    await db.execute(
+      'ALTER TABLE sync_queue ADD COLUMN sequence INTEGER NOT NULL DEFAULT 0',
+    );
   }
 }
 

--- a/test/features/race/race_time_providers_test.dart
+++ b/test/features/race/race_time_providers_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:rep_swim/core/sync/sync_mode.dart';
+import 'package:rep_swim/database/daos/race_time_dao.dart';
+import 'package:rep_swim/database/daos/sync_queue_dao.dart';
+import 'package:rep_swim/features/race/domain/entities/race_time.dart';
+import 'package:rep_swim/features/race/presentation/providers/race_time_providers.dart';
+
+class _MockRaceTimeDao extends Mock implements RaceTimeDao {}
+
+class _MockSyncQueueDao extends Mock implements SyncQueueDao {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_raceTime());
+    registerFallbackValue(<String, Object?>{});
+    registerFallbackValue(SyncOperation.create);
+  });
+
+  test('addRaceTime persists and queues a create mutation', () async {
+    final dao = _MockRaceTimeDao();
+    final queue = _MockSyncQueueDao();
+    when(() => dao.getAll(any())).thenAnswer((_) async => []);
+    when(() => dao.insertOrUpdate(any())).thenAnswer((_) async {});
+    when(
+      () => queue.enqueue(
+        profileId: any(named: 'profileId'),
+        entityType: any(named: 'entityType'),
+        entityId: any(named: 'entityId'),
+        operation: any(named: 'operation'),
+        payload: any(named: 'payload'),
+      ),
+    ).thenAnswer((_) async {});
+
+    final notifier = RaceTimesNotifier(
+      dao,
+      'profile-1',
+      syncQueueDao: queue,
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    final created = await notifier.addRaceTime(
+      raceName: ' State Sprint ',
+      eventDate: DateTime.utc(2024, 5, 1),
+      distance: 100,
+      stroke: 'Freestyle',
+      course: RaceCourse.longCourseMeters,
+      time: const Duration(seconds: 59),
+      notes: ' final ',
+    );
+
+    expect(created.raceName, 'State Sprint');
+    expect(created.notes, 'final');
+    verify(() => dao.insertOrUpdate(any())).called(1);
+    verify(
+      () => queue.enqueue(
+        profileId: 'profile-1',
+        entityType: 'race_time',
+        entityId: created.id,
+        operation: SyncOperation.create,
+        payload: any(named: 'payload'),
+      ),
+    ).called(1);
+  });
+
+  test('deleteRaceTime does not block local delete when queue fails', () async {
+    final dao = _MockRaceTimeDao();
+    final queue = _MockSyncQueueDao();
+    Object? reportedError;
+    when(() => dao.getAll(any())).thenAnswer((_) async => []);
+    when(() => dao.delete(any(), any())).thenAnswer((_) async {});
+    when(
+      () => queue.enqueue(
+        profileId: any(named: 'profileId'),
+        entityType: any(named: 'entityType'),
+        entityId: any(named: 'entityId'),
+        operation: any(named: 'operation'),
+        payload: any(named: 'payload'),
+      ),
+    ).thenThrow(Exception('queue down'));
+
+    final notifier = RaceTimesNotifier(
+      dao,
+      'profile-1',
+      syncQueueDao: queue,
+      onQueueFailure: (error) => reportedError = error,
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    await notifier.deleteRaceTime('race-1');
+
+    verify(() => dao.delete('race-1', 'profile-1')).called(1);
+    expect(reportedError, isA<Exception>());
+  });
+}
+
+RaceTime _raceTime() {
+  return RaceTime(
+    id: 'race-1',
+    profileId: 'profile-1',
+    raceName: 'Club Champs',
+    eventDate: DateTime.utc(2024, 5, 1),
+    distance: 100,
+    stroke: 'Freestyle',
+    course: RaceCourse.shortCourseMeters,
+    time: const Duration(seconds: 60),
+    createdAt: DateTime.utc(2024, 5, 1),
+    updatedAt: DateTime.utc(2024, 5, 1),
+  );
+}

--- a/test/features/race/race_time_service_test.dart
+++ b/test/features/race/race_time_service_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/race/domain/entities/race_time.dart';
+import 'package:rep_swim/features/race/domain/services/race_time_service.dart';
+
+void main() {
+  group('filterRaceTimes', () {
+    test('filters by query, distance, and course then sorts by fastest', () {
+      final races = [
+        _race(
+          id: 'slow',
+          raceName: 'State Sprint',
+          distance: 100,
+          course: RaceCourse.longCourseMeters,
+          time: const Duration(seconds: 62),
+        ),
+        _race(
+          id: 'fast',
+          raceName: 'State Sprint',
+          distance: 100,
+          course: RaceCourse.longCourseMeters,
+          time: const Duration(seconds: 58),
+        ),
+        _race(
+          id: 'other-course',
+          raceName: 'State Sprint',
+          distance: 100,
+          course: RaceCourse.shortCourseMeters,
+          time: const Duration(seconds: 55),
+        ),
+      ];
+
+      final filtered = filterRaceTimes(
+        races,
+        query: 'state',
+        distance: 100,
+        course: RaceCourse.longCourseMeters,
+        sort: RaceTimeSort.fastest,
+      );
+
+      expect(filtered.map((race) => race.id), ['fast', 'slow']);
+    });
+  });
+
+  group('bestRaceTimesByEventCourse', () {
+    test('keeps short-course and long-course bests separate', () {
+      final races = [
+        _race(
+          id: 'lcm',
+          course: RaceCourse.longCourseMeters,
+          time: const Duration(seconds: 61),
+        ),
+        _race(
+          id: 'scm',
+          course: RaceCourse.shortCourseMeters,
+          time: const Duration(seconds: 59),
+        ),
+        _race(
+          id: 'lcm-faster',
+          course: RaceCourse.longCourseMeters,
+          time: const Duration(seconds: 60),
+        ),
+      ];
+
+      final best = bestRaceTimesByEventCourse(races);
+
+      expect(best.map((race) => race.id), ['lcm-faster', 'scm']);
+    });
+  });
+}
+
+RaceTime _race({
+  required String id,
+  String profileId = 'profile-1',
+  String raceName = 'Club Champs',
+  int distance = 100,
+  RaceCourse course = RaceCourse.shortCourseMeters,
+  Duration time = const Duration(seconds: 60),
+}) {
+  return RaceTime(
+    id: id,
+    profileId: profileId,
+    raceName: raceName,
+    eventDate: DateTime.utc(2024, 5, 1),
+    distance: distance,
+    stroke: 'Freestyle',
+    course: course,
+    time: time,
+    createdAt: DateTime.utc(2024, 5, 1),
+    updatedAt: DateTime.utc(2024, 5, 1),
+  );
+}

--- a/test/features/race/race_times_screen_test.dart
+++ b/test/features/race/race_times_screen_test.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:rep_swim/database/daos/race_time_dao.dart';
+import 'package:rep_swim/features/profiles/domain/entities/swimmer_profile.dart';
+import 'package:rep_swim/features/profiles/presentation/providers/profile_providers.dart';
+import 'package:rep_swim/features/race/domain/entities/race_time.dart';
+import 'package:rep_swim/features/race/presentation/providers/race_time_providers.dart';
+import 'package:rep_swim/features/race/presentation/screens/race_times_screen.dart';
+
+void main() {
+  group('RaceTimesScreen', () {
+    testWidgets('shows empty state', (tester) async {
+      await _pumpRaceTimes(tester, []);
+
+      expect(find.text('Race Times'), findsOneWidget);
+      expect(find.text('No race times match your filters'), findsOneWidget);
+    });
+
+    testWidgets('adds a race time with validated official time',
+        (tester) async {
+      await _pumpRaceTimes(tester, []);
+
+      await tester.tap(find.text('Add Race'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Race or meet'),
+        'State Sprint',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Distance (m)'),
+        '50',
+      );
+      await tester.enterText(find.widgetWithText(TextFormField, 'Min'), '0');
+      await tester.enterText(find.widgetWithText(TextFormField, 'Sec'), '28');
+      await tester.enterText(find.widgetWithText(TextFormField, 'Csec'), '45');
+      await tester.tap(find.widgetWithText(FilledButton, 'Add'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('50m Freestyle'), findsOneWidget);
+      expect(find.textContaining('State Sprint - Short course meters'),
+          findsOneWidget);
+      expect(find.text('00:28.45'), findsOneWidget);
+    });
+
+    testWidgets('validates required race name and non-zero time',
+        (tester) async {
+      await _pumpRaceTimes(tester, []);
+
+      await tester.tap(find.text('Add Race'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, 'Add'));
+      await tester.pump();
+
+      expect(find.text('Required'), findsOneWidget);
+      expect(find.text('Enter time'), findsOneWidget);
+    });
+
+    testWidgets('filters race times by search text', (tester) async {
+      await _pumpRaceTimes(tester, [
+        _race(id: 'race-1', raceName: 'State Sprint'),
+        _race(id: 'race-2', raceName: 'Club Night'),
+      ]);
+
+      expect(find.textContaining('State Sprint - Short course meters'),
+          findsOneWidget);
+      expect(find.textContaining('Club Night - Short course meters'),
+          findsOneWidget);
+
+      await tester.enterText(find.byType(TextField).first, 'state');
+      await tester.pump();
+
+      expect(find.textContaining('State Sprint - Short course meters'),
+          findsOneWidget);
+      expect(find.textContaining('Club Night - Short course meters'),
+          findsNothing);
+    });
+
+    testWidgets('edits and deletes race times', (tester) async {
+      await _pumpRaceTimes(tester, [_race(id: 'race-1')]);
+
+      await tester.tap(find.byTooltip('Edit race time'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Race or meet'),
+        'Updated Meet',
+      );
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Updated Meet - Short course meters'),
+          findsOneWidget);
+
+      await tester.tap(find.byTooltip('Delete race time'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Updated Meet - Short course meters'),
+          findsNothing);
+      expect(find.text('No race times match your filters'), findsOneWidget);
+    });
+  });
+}
+
+Future<void> _pumpRaceTimes(
+  WidgetTester tester,
+  List<RaceTime> raceTimes,
+) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        currentProfileProvider.overrideWithValue(
+          SwimmerProfile(
+            id: 'profile-1',
+            displayName: 'Sophie',
+            createdAt: DateTime(2024),
+            updatedAt: DateTime(2024),
+          ),
+        ),
+        raceTimesProvider.overrideWith(
+          (ref) => _MutableRaceTimesNotifier(raceTimes),
+        ),
+      ],
+      child: const MaterialApp(home: RaceTimesScreen()),
+    ),
+  );
+  await tester.pump();
+}
+
+RaceTime _race({
+  required String id,
+  String raceName = 'Club Champs',
+}) {
+  return RaceTime(
+    id: id,
+    profileId: 'profile-1',
+    raceName: raceName,
+    eventDate: DateTime(2024, 5, 1),
+    distance: 100,
+    stroke: 'Freestyle',
+    course: RaceCourse.shortCourseMeters,
+    time: const Duration(seconds: 58, milliseconds: 210),
+    createdAt: DateTime(2024, 5, 1),
+    updatedAt: DateTime(2024, 5, 1),
+  );
+}
+
+class _MutableRaceTimesNotifier extends RaceTimesNotifier {
+  _MutableRaceTimesNotifier(List<RaceTime> raceTimes)
+      : _raceTimes = [...raceTimes],
+        super(_NoopRaceTimeDao(), 'profile-1') {
+    state = AsyncValue.data([..._raceTimes]);
+  }
+
+  final List<RaceTime> _raceTimes;
+  int _nextId = 0;
+
+  @override
+  Future<void> load() async {
+    state = AsyncValue.data([..._raceTimes]);
+  }
+
+  @override
+  Future<RaceTime> addRaceTime({
+    required String raceName,
+    required DateTime eventDate,
+    required int distance,
+    required String stroke,
+    required RaceCourse course,
+    required Duration time,
+    String? notes,
+    int? placement,
+    String? location,
+  }) async {
+    final raceTime = RaceTime(
+      id: 'created-${++_nextId}',
+      profileId: 'profile-1',
+      raceName: raceName,
+      eventDate: eventDate,
+      distance: distance,
+      stroke: stroke,
+      course: course,
+      time: time,
+      notes: notes,
+      placement: placement,
+      location: location,
+      createdAt: DateTime(2024),
+      updatedAt: DateTime(2024),
+    );
+    _raceTimes.add(raceTime);
+    await load();
+    return raceTime;
+  }
+
+  @override
+  Future<void> updateRaceTime(RaceTime raceTime) async {
+    final index = _raceTimes.indexWhere((item) => item.id == raceTime.id);
+    if (index >= 0) {
+      _raceTimes[index] = raceTime;
+    }
+    await load();
+  }
+
+  @override
+  Future<void> deleteRaceTime(String id) async {
+    _raceTimes.removeWhere((raceTime) => raceTime.id == id);
+    await load();
+  }
+}
+
+class _NoopRaceTimeDao extends Mock implements RaceTimeDao {}


### PR DESCRIPTION
## Summary
- Add race time domain model, DAO, provider, sync payload, and database migration
- Add the Races screen with add/edit/delete flows, filtering, sorting, and course-specific best summaries
- Add navigation entry for race times

## Tests
- flutter analyze
- flutter test

Closes #5