### PR TITLE
feat: add swim tempo trainer

### DIFF
--- a/docs/tempo-trainer.md
+++ b/docs/tempo-trainer.md
@@ -1,0 +1,206 @@
+# Tempo Trainer
+
+Tempo Trainer is an offline-first training screen for configuring and running
+rhythm cues for swim cadence, wall pacing, and breathing rhythm. It is available
+from the Home screen quick actions and directly at the `/tempo` route.
+
+The current implementation is an MVP for issue 13. It provides configurable
+cue timing, phone cue outputs, reusable templates, basic result logging, and CSV
+export for entered split data.
+
+## Modes
+
+Tempo Trainer supports three modes.
+
+### Stroke Rate
+
+Stroke Rate mode cues a regular beat from the configured strokes per minute.
+
+Example:
+
+- Stroke/min: `60`
+- Cue interval: `1.00` second
+- Accent every: `4`
+
+This mode is intended for cadence work, such as holding a target hand-entry or
+stroke rhythm.
+
+### Lap Pace
+
+Lap Pace mode cues each target wall split from the configured pool length,
+target distance, and target time.
+
+Example:
+
+- Pool m: `25`
+- Target m: `100`
+- Target sec: `88`
+- Cue interval: `22.00` seconds
+
+This mode is intended for "stay with the beep" pacing against a wall target.
+
+### Breath Pattern
+
+Breath Pattern mode cues a breathing rhythm from the configured stroke rate and
+`Breathe every` value.
+
+Example:
+
+- Stroke/min: `60`
+- Breathe every: `3`
+- Cue interval: `3.00` seconds
+
+Breath Pattern mode is for rhythm cues only. It is not a breath-hold challenge
+or hypoxic set builder.
+
+## Session Setup
+
+The screen exposes these inputs:
+
+- `Pool m`: pool length in meters.
+- `Target m`: target session or repeat distance in meters.
+- `Target sec`: target time in seconds.
+- `Stroke/min`: target stroke rate.
+- `Breathe every`: number of strokes between breath cues.
+- `Accent every`: beat interval for accent cues.
+
+All numeric configuration values must be positive. Invalid setup values show
+`Enter valid tempo values.` and are not applied.
+
+## Cue Outputs
+
+Cue output settings are configured with chips:
+
+- `Sound`: plays a platform system sound on each cue.
+- `Vibration`: triggers light haptic feedback for normal cues and heavier
+  haptic feedback for accent cues.
+- `Visual flash`: briefly changes the run panel background on each cue.
+- `Voice alert`: sends a semantic announcement for assistive voice output.
+
+The cue player is implemented behind `TempoCuePlayer` so tests can inject a fake
+cue player without calling platform channels.
+
+Current timing uses Flutter timers. This is adequate for the MVP but is not a
+specialized low-drift audio scheduler.
+
+## Safety Behavior
+
+Breath Pattern mode requires explicit safety acknowledgement when `Breathe every`
+is `5` or higher. Until acknowledged, the Start button is disabled.
+
+The safety copy shown in the app states that breath cues are for rhythm only and
+should not be used for max breath holds, underwater distance challenges, or
+unsupervised hypoxic sets.
+
+## Running A Session
+
+The run panel shows:
+
+- Current cue label, such as `Stroke cue`, `Wall cue`, `Breathe cue`, or
+  `Accent cue`.
+- Cue interval.
+- Target wall split.
+- Target pace per 100m.
+- Beat count.
+- Elapsed cue time.
+
+Controls:
+
+- `Start`: starts cue playback.
+- `Pause`: pauses cue playback.
+- `Reset`: stops playback and clears beat count and elapsed cue time.
+
+## Templates
+
+Tempo configurations can be saved as reusable templates. A template stores:
+
+- Name.
+- Mode.
+- Pool length.
+- Target distance.
+- Target time.
+- Stroke rate.
+- Breath interval.
+- Cue output settings.
+- Accent interval.
+- Safety acknowledgement state.
+
+Templates are stored in SQLite in `tempo_templates` and are scoped to the current
+swimmer profile. Template changes are also queued for sync using the local sync
+queue.
+
+## Session Results
+
+The Session Result panel lets the user enter:
+
+- Actual splits in seconds, comma separated.
+- Stroke counts, comma separated.
+- RPE from 1 to 10.
+- Notes.
+
+At least one actual split is required to save a result. RPE must be blank or in
+the range `1..10`.
+
+Saved results are stored in SQLite in `tempo_session_results` and are scoped to
+the current swimmer profile. Result creates are queued for sync.
+
+The MVP stores results and shows a count of saved tempo sessions. It does not
+yet include a dedicated history or detail screen for viewing saved results.
+
+## CSV Export
+
+The `CSV` button copies CSV for the currently entered split data to the system
+clipboard. The CSV includes:
+
+- Session id.
+- Mode.
+- Split index.
+- Target split in milliseconds.
+- Actual split in milliseconds.
+- Split error in milliseconds.
+- Stroke count.
+
+CSV export does not require saving the result first.
+
+## Persistence
+
+Tempo Trainer adds database version `12` with these tables:
+
+- `tempo_templates`
+- `tempo_session_results`
+
+The training template DAO owns tempo template and tempo result persistence
+alongside the existing interval and dryland template storage.
+
+## Tests
+
+Current coverage includes:
+
+- Unit tests for tempo conversions, split comparison, breath safety thresholds,
+  and CSV export.
+- Provider tests for cue scheduling, template save/delete, result save, and sync
+  queue behavior.
+- Widget tests for controls, safety acknowledgement, validation, template save,
+  result save, and CSV copy.
+- DAO integration tests for offline persistence and profile isolation.
+- Migration tests for upgrading older database versions to the tempo schema.
+
+## Current Limitations
+
+The MVP intentionally does not include:
+
+- Low-drift audio scheduling.
+- Saved session history/detail screens.
+- CSS pace preset generation.
+- Stroke-rate ramp tests.
+- USRPT race-pace presets and fail counters.
+- Per-rep or per-segment race modelling.
+- Wearable, Bluetooth, or external device integration.
+
+Follow-up issues:
+
+- #15 Tempo session history/detail views.
+- #16 Low-drift audio scheduling.
+- #17 CSS pace preset builder.
+- #18 USRPT race-pace preset with fail counter.
+- #19 Stroke-rate ramp test preset.

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -11,6 +11,7 @@ import 'features/swim/presentation/screens/swim_session_screen.dart';
 import 'features/stopwatch/presentation/screens/stopwatch_screen.dart';
 import 'features/stopwatch/presentation/screens/interval_timer_screen.dart';
 import 'features/stopwatch/presentation/providers/stopwatch_display_style_provider.dart';
+import 'features/tempo/presentation/screens/tempo_trainer_screen.dart';
 import 'features/pb/presentation/screens/pb_screen.dart';
 import 'features/profiles/presentation/screens/profiles_screen.dart';
 import 'features/race/presentation/screens/qualification_standards_screen.dart';
@@ -86,6 +87,10 @@ final _router = GoRouter(
     GoRoute(
       path: '/intervals',
       builder: (context, state) => const IntervalTimerScreen(),
+    ),
+    GoRoute(
+      path: '/tempo',
+      builder: (context, state) => const TempoTrainerScreen(),
     ),
     GoRoute(
       path: '/settings/sync',

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -10,7 +10,7 @@ const List<String> kStrokes = [
 const List<int> kStandardDistances = [25, 50, 100, 200, 400, 800, 1500];
 
 const String kAppName = 'repSwim';
-const int kDbVersion = 11;
+const int kDbVersion = 12;
 const String kDefaultProfileId = 'local-default-profile';
 const String kDefaultProfileName = 'Default Swimmer';
 const String kSelectedProfileIdSetting = 'selected_profile_id';

--- a/lib/core/sync/sync_payloads.dart
+++ b/lib/core/sync/sync_payloads.dart
@@ -1,3 +1,5 @@
+import '../../features/tempo/domain/entities/tempo_session_result.dart';
+import '../../features/tempo/domain/entities/tempo_template.dart';
 import '../../features/dryland/domain/entities/dryland_workout.dart';
 import '../../features/dryland/domain/entities/exercise.dart';
 import '../../features/profiles/domain/entities/swimmer_profile.dart';
@@ -117,6 +119,49 @@ Map<String, Object?> intervalTemplatePayload(IntervalTemplate template) {
     'restSeconds': template.restDuration.inSeconds,
     'createdAt': template.createdAt.toUtc().millisecondsSinceEpoch,
     'updatedAt': template.updatedAt.toUtc().millisecondsSinceEpoch,
+  };
+}
+
+Map<String, Object?> tempoTemplatePayload(TempoTemplate template) {
+  return {
+    'id': template.id,
+    'profileId': template.profileId,
+    'name': template.name,
+    'mode': template.mode.name,
+    'poolLengthMeters': template.poolLengthMeters,
+    'targetDistanceMeters': template.targetDistanceMeters,
+    'targetTimeMilliseconds': template.targetTime.inMilliseconds,
+    'strokeRate': template.strokeRate,
+    'breathEveryStrokes': template.breathEveryStrokes,
+    'audibleEnabled': template.cueSettings.audible,
+    'vibrationEnabled': template.cueSettings.vibration,
+    'visualFlashEnabled': template.cueSettings.visualFlash,
+    'spokenEnabled': template.cueSettings.spoken,
+    'accentEvery': template.cueSettings.accentEvery,
+    'safetyWarningAcknowledged': template.safetyWarningAcknowledged,
+    'createdAt': template.createdAt.toUtc().millisecondsSinceEpoch,
+    'updatedAt': template.updatedAt.toUtc().millisecondsSinceEpoch,
+  };
+}
+
+Map<String, Object?> tempoSessionResultPayload(TempoSessionResult result) {
+  return {
+    'id': result.id,
+    'profileId': result.profileId,
+    'templateId': result.templateId,
+    'mode': result.mode.name,
+    'startedAt': result.startedAt.toUtc().millisecondsSinceEpoch,
+    'completedAt': result.completedAt?.toUtc().millisecondsSinceEpoch,
+    'targetDistanceMeters': result.targetDistanceMeters,
+    'poolLengthMeters': result.poolLengthMeters,
+    'targetTimeMilliseconds': result.targetTime.inMilliseconds,
+    'targetStrokeRate': result.targetStrokeRate,
+    'actualSplitsMilliseconds': [
+      for (final split in result.actualSplits) split.inMilliseconds,
+    ],
+    'strokeCounts': result.strokeCounts,
+    'rpe': result.rpe,
+    'notes': result.notes,
   };
 }
 

--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -182,6 +182,9 @@ class AppDatabase {
     if (oldVersion < 11) {
       await _createMeetQualificationStandardsTable(db);
     }
+    if (oldVersion < 12) {
+      await _createTempoTables(db);
+    }
   }
 
   Future<void> _createIndexes(Database db) async {
@@ -327,6 +330,61 @@ class AppDatabase {
         weight REAL,
         FOREIGN KEY (template_id) REFERENCES dryland_routine_templates(id) ON DELETE CASCADE
       )
+    ''');
+
+    await _createTempoTables(db);
+  }
+
+  Future<void> _createTempoTables(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS tempo_templates (
+        id TEXT PRIMARY KEY,
+        profile_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        mode TEXT NOT NULL,
+        pool_length_meters INTEGER NOT NULL,
+        target_distance_meters INTEGER NOT NULL,
+        target_time_milliseconds INTEGER NOT NULL,
+        stroke_rate REAL NOT NULL,
+        breath_every_strokes INTEGER NOT NULL,
+        audible_enabled INTEGER NOT NULL,
+        vibration_enabled INTEGER NOT NULL,
+        visual_flash_enabled INTEGER NOT NULL,
+        spoken_enabled INTEGER NOT NULL,
+        accent_every INTEGER NOT NULL,
+        safety_warning_acknowledged INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    ''');
+
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS tempo_session_results (
+        id TEXT PRIMARY KEY,
+        profile_id TEXT NOT NULL,
+        template_id TEXT,
+        mode TEXT NOT NULL,
+        started_at INTEGER NOT NULL,
+        completed_at INTEGER,
+        target_distance_meters INTEGER NOT NULL,
+        pool_length_meters INTEGER NOT NULL,
+        target_time_milliseconds INTEGER NOT NULL,
+        target_stroke_rate REAL NOT NULL,
+        actual_splits_milliseconds_json TEXT NOT NULL,
+        stroke_counts_json TEXT NOT NULL,
+        rpe INTEGER,
+        notes TEXT
+      )
+    ''');
+
+    await db.execute('''
+      CREATE INDEX IF NOT EXISTS idx_tempo_templates_profile_name
+      ON tempo_templates(profile_id, name COLLATE NOCASE)
+    ''');
+
+    await db.execute('''
+      CREATE INDEX IF NOT EXISTS idx_tempo_session_results_profile_started
+      ON tempo_session_results(profile_id, started_at DESC)
     ''');
   }
 

--- a/lib/database/daos/training_template_dao.dart
+++ b/lib/database/daos/training_template_dao.dart
@@ -1,5 +1,10 @@
+import 'dart:convert';
+
 import 'package:sqflite/sqflite.dart';
 
+import '../../features/tempo/domain/entities/tempo_mode.dart';
+import '../../features/tempo/domain/entities/tempo_session_result.dart';
+import '../../features/tempo/domain/entities/tempo_template.dart';
 import '../../features/templates/domain/entities/dryland_routine_template.dart';
 import '../../features/templates/domain/entities/interval_template.dart';
 import '../app_database.dart';
@@ -120,6 +125,93 @@ class TrainingTemplateDao {
     );
   }
 
+  Future<List<TempoTemplate>> getTempoTemplates(String profileId) async {
+    final db = await _db.database;
+    final rows = await db.query(
+      'tempo_templates',
+      where: 'profile_id = ?',
+      whereArgs: [profileId],
+      orderBy: 'name COLLATE NOCASE ASC',
+    );
+    return rows.map(_tempoTemplateFromRow).toList();
+  }
+
+  Future<void> insertTempoTemplate(TempoTemplate template) async {
+    final db = await _db.database;
+    await db.insert(
+      'tempo_templates',
+      {
+        'id': template.id,
+        'profile_id': template.profileId,
+        'name': template.name,
+        'mode': template.mode.name,
+        'pool_length_meters': template.poolLengthMeters,
+        'target_distance_meters': template.targetDistanceMeters,
+        'target_time_milliseconds': template.targetTime.inMilliseconds,
+        'stroke_rate': template.strokeRate,
+        'breath_every_strokes': template.breathEveryStrokes,
+        'audible_enabled': template.cueSettings.audible ? 1 : 0,
+        'vibration_enabled': template.cueSettings.vibration ? 1 : 0,
+        'visual_flash_enabled': template.cueSettings.visualFlash ? 1 : 0,
+        'spoken_enabled': template.cueSettings.spoken ? 1 : 0,
+        'accent_every': template.cueSettings.accentEvery,
+        'safety_warning_acknowledged':
+            template.safetyWarningAcknowledged ? 1 : 0,
+        'created_at': template.createdAt.millisecondsSinceEpoch,
+        'updated_at': template.updatedAt.millisecondsSinceEpoch,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  Future<void> deleteTempoTemplate(String id, String profileId) async {
+    final db = await _db.database;
+    await db.delete(
+      'tempo_templates',
+      where: 'id = ? AND profile_id = ?',
+      whereArgs: [id, profileId],
+    );
+  }
+
+  Future<void> insertTempoSessionResult(TempoSessionResult result) async {
+    final db = await _db.database;
+    await db.insert(
+      'tempo_session_results',
+      {
+        'id': result.id,
+        'profile_id': result.profileId,
+        'template_id': result.templateId,
+        'mode': result.mode.name,
+        'started_at': result.startedAt.millisecondsSinceEpoch,
+        'completed_at': result.completedAt?.millisecondsSinceEpoch,
+        'target_distance_meters': result.targetDistanceMeters,
+        'pool_length_meters': result.poolLengthMeters,
+        'target_time_milliseconds': result.targetTime.inMilliseconds,
+        'target_stroke_rate': result.targetStrokeRate,
+        'actual_splits_milliseconds_json': jsonEncode(
+          result.actualSplits.map((split) => split.inMilliseconds).toList(),
+        ),
+        'stroke_counts_json': jsonEncode(result.strokeCounts),
+        'rpe': result.rpe,
+        'notes': result.notes,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  Future<List<TempoSessionResult>> getTempoSessionResults(
+    String profileId,
+  ) async {
+    final db = await _db.database;
+    final rows = await db.query(
+      'tempo_session_results',
+      where: 'profile_id = ?',
+      whereArgs: [profileId],
+      orderBy: 'started_at DESC',
+    );
+    return rows.map(_tempoSessionResultFromRow).toList();
+  }
+
   Future<List<DrylandRoutineExerciseTemplate>> getDrylandRoutineExercises(
     String templateId,
     String profileId,
@@ -186,6 +278,76 @@ class TrainingTemplateDao {
       sets: row['sets'] as int,
       reps: row['reps'] as int,
       weight: row['weight'] as double?,
+    );
+  }
+
+  TempoTemplate _tempoTemplateFromRow(Map<String, Object?> row) {
+    return TempoTemplate(
+      id: row['id'] as String,
+      profileId: row['profile_id'] as String,
+      name: row['name'] as String,
+      mode: tempoModeFromName(row['mode'] as String),
+      poolLengthMeters: row['pool_length_meters'] as int,
+      targetDistanceMeters: row['target_distance_meters'] as int,
+      targetTime: Duration(
+        milliseconds: row['target_time_milliseconds'] as int,
+      ),
+      strokeRate: (row['stroke_rate'] as num).toDouble(),
+      breathEveryStrokes: row['breath_every_strokes'] as int,
+      cueSettings: TempoCueSettings(
+        audible: row['audible_enabled'] == 1,
+        vibration: row['vibration_enabled'] == 1,
+        visualFlash: row['visual_flash_enabled'] == 1,
+        spoken: row['spoken_enabled'] == 1,
+        accentEvery: row['accent_every'] as int,
+      ),
+      safetyWarningAcknowledged: row['safety_warning_acknowledged'] == 1,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(
+        row['created_at'] as int,
+        isUtc: true,
+      ),
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(
+        row['updated_at'] as int,
+        isUtc: true,
+      ),
+    );
+  }
+
+  TempoSessionResult _tempoSessionResultFromRow(Map<String, Object?> row) {
+    final splitValues =
+        (jsonDecode(row['actual_splits_milliseconds_json'] as String) as List)
+            .cast<int>();
+    final strokeCounts =
+        (jsonDecode(row['stroke_counts_json'] as String) as List).cast<int>();
+
+    return TempoSessionResult(
+      id: row['id'] as String,
+      profileId: row['profile_id'] as String,
+      templateId: row['template_id'] as String?,
+      mode: tempoModeFromName(row['mode'] as String),
+      startedAt: DateTime.fromMillisecondsSinceEpoch(
+        row['started_at'] as int,
+        isUtc: true,
+      ),
+      completedAt: row['completed_at'] == null
+          ? null
+          : DateTime.fromMillisecondsSinceEpoch(
+              row['completed_at'] as int,
+              isUtc: true,
+            ),
+      targetDistanceMeters: row['target_distance_meters'] as int,
+      poolLengthMeters: row['pool_length_meters'] as int,
+      targetTime: Duration(
+        milliseconds: row['target_time_milliseconds'] as int,
+      ),
+      targetStrokeRate: (row['target_stroke_rate'] as num).toDouble(),
+      actualSplits: [
+        for (final milliseconds in splitValues)
+          Duration(milliseconds: milliseconds),
+      ],
+      strokeCounts: strokeCounts,
+      rpe: row['rpe'] as int?,
+      notes: row['notes'] as String?,
     );
   }
 }

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -359,6 +359,18 @@ class _QuickActions extends StatelessWidget {
               const SizedBox(width: 12),
               Expanded(
                 child: _ActionCard(
+                  icon: Icons.graphic_eq,
+                  label: 'Tempo',
+                  onTap: () => context.push('/tempo'),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: _ActionCard(
                   icon: Icons.bar_chart,
                   label: 'Analytics',
                   onTap: () => context.push('/analytics'),

--- a/lib/features/tempo/domain/entities/tempo_mode.dart
+++ b/lib/features/tempo/domain/entities/tempo_mode.dart
@@ -1,0 +1,20 @@
+enum TempoMode {
+  strokeRate,
+  lapPace,
+  breathPattern;
+
+  String get label {
+    return switch (this) {
+      TempoMode.strokeRate => 'Stroke Rate',
+      TempoMode.lapPace => 'Lap Pace',
+      TempoMode.breathPattern => 'Breath Pattern',
+    };
+  }
+}
+
+TempoMode tempoModeFromName(String name) {
+  return TempoMode.values.firstWhere(
+    (mode) => mode.name == name,
+    orElse: () => TempoMode.strokeRate,
+  );
+}

--- a/lib/features/tempo/domain/entities/tempo_session_result.dart
+++ b/lib/features/tempo/domain/entities/tempo_session_result.dart
@@ -1,0 +1,53 @@
+import '../../../../core/constants/app_constants.dart';
+import 'tempo_mode.dart';
+
+class TempoSplitResult {
+  const TempoSplitResult({
+    required this.index,
+    required this.targetSplit,
+    required this.actualSplit,
+    this.strokeCount,
+  });
+
+  final int index;
+  final Duration targetSplit;
+  final Duration actualSplit;
+  final int? strokeCount;
+
+  Duration get error => actualSplit - targetSplit;
+  bool get isOnPace => error.inMilliseconds.abs() <= 500;
+}
+
+class TempoSessionResult {
+  const TempoSessionResult({
+    required this.id,
+    required this.mode,
+    required this.startedAt,
+    required this.targetDistanceMeters,
+    required this.poolLengthMeters,
+    required this.targetTime,
+    required this.targetStrokeRate,
+    required this.actualSplits,
+    required this.strokeCounts,
+    this.profileId = kDefaultProfileId,
+    this.templateId,
+    this.completedAt,
+    this.rpe,
+    this.notes,
+  });
+
+  final String id;
+  final String profileId;
+  final String? templateId;
+  final TempoMode mode;
+  final DateTime startedAt;
+  final DateTime? completedAt;
+  final int targetDistanceMeters;
+  final int poolLengthMeters;
+  final Duration targetTime;
+  final double targetStrokeRate;
+  final List<Duration> actualSplits;
+  final List<int> strokeCounts;
+  final int? rpe;
+  final String? notes;
+}

--- a/lib/features/tempo/domain/entities/tempo_template.dart
+++ b/lib/features/tempo/domain/entities/tempo_template.dart
@@ -1,0 +1,99 @@
+import '../../../../core/constants/app_constants.dart';
+import 'tempo_mode.dart';
+
+class TempoCueSettings {
+  const TempoCueSettings({
+    this.audible = true,
+    this.vibration = false,
+    this.visualFlash = true,
+    this.spoken = false,
+    this.accentEvery = 4,
+  });
+
+  final bool audible;
+  final bool vibration;
+  final bool visualFlash;
+  final bool spoken;
+  final int accentEvery;
+
+  TempoCueSettings copyWith({
+    bool? audible,
+    bool? vibration,
+    bool? visualFlash,
+    bool? spoken,
+    int? accentEvery,
+  }) {
+    return TempoCueSettings(
+      audible: audible ?? this.audible,
+      vibration: vibration ?? this.vibration,
+      visualFlash: visualFlash ?? this.visualFlash,
+      spoken: spoken ?? this.spoken,
+      accentEvery: accentEvery ?? this.accentEvery,
+    );
+  }
+}
+
+class TempoTemplate {
+  const TempoTemplate({
+    required this.id,
+    required this.name,
+    required this.mode,
+    required this.poolLengthMeters,
+    required this.targetDistanceMeters,
+    required this.targetTime,
+    required this.strokeRate,
+    required this.breathEveryStrokes,
+    required this.cueSettings,
+    required this.safetyWarningAcknowledged,
+    required this.createdAt,
+    required this.updatedAt,
+    this.profileId = kDefaultProfileId,
+  });
+
+  final String id;
+  final String profileId;
+  final String name;
+  final TempoMode mode;
+  final int poolLengthMeters;
+  final int targetDistanceMeters;
+  final Duration targetTime;
+  final double strokeRate;
+  final int breathEveryStrokes;
+  final TempoCueSettings cueSettings;
+  final bool safetyWarningAcknowledged;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  TempoTemplate copyWith({
+    String? id,
+    String? profileId,
+    String? name,
+    TempoMode? mode,
+    int? poolLengthMeters,
+    int? targetDistanceMeters,
+    Duration? targetTime,
+    double? strokeRate,
+    int? breathEveryStrokes,
+    TempoCueSettings? cueSettings,
+    bool? safetyWarningAcknowledged,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return TempoTemplate(
+      id: id ?? this.id,
+      profileId: profileId ?? this.profileId,
+      name: name ?? this.name,
+      mode: mode ?? this.mode,
+      poolLengthMeters: poolLengthMeters ?? this.poolLengthMeters,
+      targetDistanceMeters: targetDistanceMeters ?? this.targetDistanceMeters,
+      targetTime: targetTime ?? this.targetTime,
+      strokeRate: strokeRate ?? this.strokeRate,
+      breathEveryStrokes: breathEveryStrokes ?? this.breathEveryStrokes,
+      cueSettings: cueSettings ?? this.cueSettings,
+      safetyWarningAcknowledged:
+          safetyWarningAcknowledged ?? this.safetyWarningAcknowledged,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+}

--- a/lib/features/tempo/domain/services/tempo_calculator.dart
+++ b/lib/features/tempo/domain/services/tempo_calculator.dart
@@ -1,0 +1,87 @@
+import '../entities/tempo_session_result.dart';
+
+class TempoCalculator {
+  const TempoCalculator();
+
+  Duration beatIntervalForStrokeRate(double strokesPerMinute) {
+    if (strokesPerMinute <= 0) {
+      throw ArgumentError.value(strokesPerMinute, 'strokesPerMinute');
+    }
+    final microseconds =
+        (Duration.microsecondsPerMinute / strokesPerMinute).round();
+    return Duration(microseconds: microseconds);
+  }
+
+  double strokeRateForBeatInterval(Duration beatInterval) {
+    if (beatInterval <= Duration.zero) {
+      throw ArgumentError.value(beatInterval, 'beatInterval');
+    }
+    return Duration.microsecondsPerMinute / beatInterval.inMicroseconds;
+  }
+
+  Duration splitForDistance({
+    required Duration targetTime,
+    required int targetDistanceMeters,
+    required int splitDistanceMeters,
+  }) {
+    if (targetTime <= Duration.zero ||
+        targetDistanceMeters <= 0 ||
+        splitDistanceMeters <= 0) {
+      throw ArgumentError('Target time and distances must be positive.');
+    }
+    final ratio = splitDistanceMeters / targetDistanceMeters;
+    return Duration(
+      microseconds: (targetTime.inMicroseconds * ratio).round(),
+    );
+  }
+
+  Duration pacePer100({
+    required Duration targetTime,
+    required int targetDistanceMeters,
+  }) {
+    return splitForDistance(
+      targetTime: targetTime,
+      targetDistanceMeters: targetDistanceMeters,
+      splitDistanceMeters: 100,
+    );
+  }
+
+  double distancePerStroke({
+    required int distanceMeters,
+    required int strokeCount,
+  }) {
+    if (distanceMeters <= 0 || strokeCount <= 0) {
+      throw ArgumentError('Distance and stroke count must be positive.');
+    }
+    return distanceMeters / strokeCount;
+  }
+
+  List<TempoSplitResult> compareSplits({
+    required List<Duration> actualSplits,
+    required Duration targetSplit,
+    List<int> strokeCounts = const [],
+  }) {
+    return [
+      for (var i = 0; i < actualSplits.length; i++)
+        TempoSplitResult(
+          index: i + 1,
+          targetSplit: targetSplit,
+          actualSplit: actualSplits[i],
+          strokeCount: i < strokeCounts.length ? strokeCounts[i] : null,
+        ),
+    ];
+  }
+
+  Duration averageSplitError(List<TempoSplitResult> results) {
+    if (results.isEmpty) return Duration.zero;
+    final totalError = results.fold<int>(
+      0,
+      (sum, result) => sum + result.error.inMilliseconds,
+    );
+    return Duration(milliseconds: (totalError / results.length).round());
+  }
+
+  bool requiresBreathSafetyWarning(int breathEveryStrokes) {
+    return breathEveryStrokes >= 5;
+  }
+}

--- a/lib/features/tempo/domain/services/tempo_csv_exporter.dart
+++ b/lib/features/tempo/domain/services/tempo_csv_exporter.dart
@@ -1,0 +1,54 @@
+import '../entities/tempo_session_result.dart';
+
+class TempoCsvExporter {
+  const TempoCsvExporter();
+
+  String exportSession(TempoSessionResult result) {
+    final rows = <List<String>>[
+      [
+        'session_id',
+        'mode',
+        'split_index',
+        'target_split_ms',
+        'actual_split_ms',
+        'error_ms',
+        'stroke_count',
+      ],
+    ];
+
+    final targetSplit = result.targetDistanceMeters == 0
+        ? Duration.zero
+        : Duration(
+            microseconds: (result.targetTime.inMicroseconds *
+                    result.poolLengthMeters /
+                    result.targetDistanceMeters)
+                .round(),
+          );
+    final splitCount = result.actualSplits.length;
+    for (var i = 0; i < splitCount; i++) {
+      final actual = result.actualSplits[i];
+      rows.add([
+        result.id,
+        result.mode.name,
+        '${i + 1}',
+        '${targetSplit.inMilliseconds}',
+        '${actual.inMilliseconds}',
+        '${actual.inMilliseconds - targetSplit.inMilliseconds}',
+        i < result.strokeCounts.length ? '${result.strokeCounts[i]}' : '',
+      ]);
+    }
+
+    return rows.map(_csvRow).join('\n');
+  }
+
+  String _csvRow(List<String> values) {
+    return values.map(_csvCell).join(',');
+  }
+
+  String _csvCell(String value) {
+    if (!value.contains(',') && !value.contains('"') && !value.contains('\n')) {
+      return value;
+    }
+    return '"${value.replaceAll('"', '""')}"';
+  }
+}

--- a/lib/features/tempo/presentation/providers/tempo_cue_player.dart
+++ b/lib/features/tempo/presentation/providers/tempo_cue_player.dart
@@ -1,0 +1,51 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/semantics.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/tempo_template.dart';
+
+abstract class TempoCuePlayer {
+  Future<void> playCue({
+    required TempoCueSettings settings,
+    required bool accent,
+  });
+}
+
+class SystemTempoCuePlayer implements TempoCuePlayer {
+  const SystemTempoCuePlayer();
+
+  @override
+  Future<void> playCue({
+    required TempoCueSettings settings,
+    required bool accent,
+  }) async {
+    if (settings.audible || settings.spoken) {
+      await SystemSound.play(
+        accent ? SystemSoundType.alert : SystemSoundType.click,
+      );
+    }
+    if (settings.spoken) {
+      final views = ui.PlatformDispatcher.instance.views;
+      if (views.isNotEmpty) {
+        await SemanticsService.sendAnnouncement(
+          views.first,
+          accent ? 'Accent cue' : 'Tempo cue',
+          ui.TextDirection.ltr,
+        );
+      }
+    }
+    if (settings.vibration) {
+      if (accent) {
+        await HapticFeedback.heavyImpact();
+      } else {
+        await HapticFeedback.lightImpact();
+      }
+    }
+  }
+}
+
+final tempoCuePlayerProvider = Provider<TempoCuePlayer>(
+  (ref) => const SystemTempoCuePlayer(),
+);

--- a/lib/features/tempo/presentation/providers/tempo_template_providers.dart
+++ b/lib/features/tempo/presentation/providers/tempo_template_providers.dart
@@ -1,0 +1,204 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../../core/sync/sync_mode.dart';
+import '../../../../core/sync/sync_payloads.dart';
+import '../../../../core/sync/sync_providers.dart';
+import '../../../../database/daos/sync_queue_dao.dart';
+import '../../../../database/daos/training_template_dao.dart';
+import '../../../profiles/presentation/providers/profile_providers.dart';
+import '../../../templates/presentation/providers/training_template_providers.dart';
+import '../../domain/entities/tempo_session_result.dart';
+import '../../domain/entities/tempo_template.dart';
+import 'tempo_trainer_provider.dart';
+
+const _uuid = Uuid();
+
+class TempoTemplatesNotifier
+    extends StateNotifier<AsyncValue<List<TempoTemplate>>> {
+  TempoTemplatesNotifier(
+    this._dao,
+    this._profileId, {
+    SyncQueueDao? syncQueueDao,
+    void Function(Object error)? onQueueFailure,
+  })  : _syncQueueDao = syncQueueDao,
+        _onQueueFailure = onQueueFailure,
+        super(const AsyncValue.loading()) {
+    load();
+  }
+
+  final TrainingTemplateDao _dao;
+  final String _profileId;
+  final SyncQueueDao? _syncQueueDao;
+  final void Function(Object error)? _onQueueFailure;
+
+  Future<void> load() async {
+    state = const AsyncValue.loading();
+    try {
+      final templates = await _dao.getTempoTemplates(_profileId);
+      state = AsyncValue.data(templates);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  Future<TempoTemplate> saveFromState(
+    String name,
+    TempoTrainerState trainer,
+  ) async {
+    final now = DateTime.now().toUtc();
+    final template = trainer.toTemplate(
+      id: _uuid.v4(),
+      profileId: _profileId,
+      name: name.trim(),
+      now: now,
+    );
+    await _dao.insertTempoTemplate(template);
+    await _queueChange(
+      entityType: 'tempo_template',
+      entityId: template.id,
+      operation: SyncOperation.create,
+      payload: tempoTemplatePayload(template),
+    );
+    await load();
+    return template;
+  }
+
+  Future<void> deleteTemplate(String id) async {
+    await _dao.deleteTempoTemplate(id, _profileId);
+    await _queueChange(
+      entityType: 'tempo_template',
+      entityId: id,
+      operation: SyncOperation.delete,
+      payload: deletedEntityPayload(id: id, profileId: _profileId),
+    );
+    await load();
+  }
+
+  Future<void> _queueChange({
+    required String entityType,
+    required String entityId,
+    required SyncOperation operation,
+    required Map<String, Object?> payload,
+  }) async {
+    try {
+      await _syncQueueDao?.enqueue(
+        profileId: _profileId,
+        entityType: entityType,
+        entityId: entityId,
+        operation: operation,
+        payload: payload,
+      );
+    } catch (error) {
+      _onQueueFailure?.call(error);
+    }
+  }
+}
+
+final tempoTemplatesProvider = StateNotifierProvider.autoDispose<
+    TempoTemplatesNotifier, AsyncValue<List<TempoTemplate>>>(
+  (ref) => TempoTemplatesNotifier(
+    ref.read(trainingTemplateDaoProvider),
+    ref.watch(currentProfileIdProvider),
+    syncQueueDao: ref.read(syncQueueDaoProvider),
+    onQueueFailure: (error) {
+      ref.read(syncQueueFailureProvider.notifier).state = error.toString();
+    },
+  ),
+);
+
+class TempoSessionResultsNotifier
+    extends StateNotifier<AsyncValue<List<TempoSessionResult>>> {
+  TempoSessionResultsNotifier(
+    this._dao,
+    this._profileId, {
+    SyncQueueDao? syncQueueDao,
+    void Function(Object error)? onQueueFailure,
+  })  : _syncQueueDao = syncQueueDao,
+        _onQueueFailure = onQueueFailure,
+        super(const AsyncValue.loading()) {
+    load();
+  }
+
+  final TrainingTemplateDao _dao;
+  final String _profileId;
+  final SyncQueueDao? _syncQueueDao;
+  final void Function(Object error)? _onQueueFailure;
+
+  Future<void> load() async {
+    state = const AsyncValue.loading();
+    try {
+      final results = await _dao.getTempoSessionResults(_profileId);
+      state = AsyncValue.data(results);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  Future<TempoSessionResult> saveResult({
+    required TempoTrainerState trainer,
+    String? templateId,
+    required List<Duration> actualSplits,
+    required List<int> strokeCounts,
+    int? rpe,
+    String? notes,
+  }) async {
+    final now = DateTime.now().toUtc();
+    final result = TempoSessionResult(
+      id: _uuid.v4(),
+      profileId: _profileId,
+      templateId: templateId,
+      mode: trainer.mode,
+      startedAt: now,
+      completedAt: now,
+      targetDistanceMeters: trainer.targetDistanceMeters,
+      poolLengthMeters: trainer.poolLengthMeters,
+      targetTime: trainer.targetTime,
+      targetStrokeRate: trainer.strokeRate,
+      actualSplits: actualSplits,
+      strokeCounts: strokeCounts,
+      rpe: rpe,
+      notes: (notes?.trim().isEmpty ?? true) ? null : notes!.trim(),
+    );
+    await _dao.insertTempoSessionResult(result);
+    await _queueChange(
+      entityType: 'tempo_session_result',
+      entityId: result.id,
+      operation: SyncOperation.create,
+      payload: tempoSessionResultPayload(result),
+    );
+    await load();
+    return result;
+  }
+
+  Future<void> _queueChange({
+    required String entityType,
+    required String entityId,
+    required SyncOperation operation,
+    required Map<String, Object?> payload,
+  }) async {
+    try {
+      await _syncQueueDao?.enqueue(
+        profileId: _profileId,
+        entityType: entityType,
+        entityId: entityId,
+        operation: operation,
+        payload: payload,
+      );
+    } catch (error) {
+      _onQueueFailure?.call(error);
+    }
+  }
+}
+
+final tempoSessionResultsProvider = StateNotifierProvider.autoDispose<
+    TempoSessionResultsNotifier, AsyncValue<List<TempoSessionResult>>>(
+  (ref) => TempoSessionResultsNotifier(
+    ref.read(trainingTemplateDaoProvider),
+    ref.watch(currentProfileIdProvider),
+    syncQueueDao: ref.read(syncQueueDaoProvider),
+    onQueueFailure: (error) {
+      ref.read(syncQueueFailureProvider.notifier).state = error.toString();
+    },
+  ),
+);

--- a/lib/features/tempo/presentation/providers/tempo_trainer_provider.dart
+++ b/lib/features/tempo/presentation/providers/tempo_trainer_provider.dart
@@ -1,0 +1,234 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/tempo_mode.dart';
+import '../../domain/entities/tempo_template.dart';
+import '../../domain/services/tempo_calculator.dart';
+import 'tempo_cue_player.dart';
+
+class TempoTrainerState {
+  const TempoTrainerState({
+    this.mode = TempoMode.strokeRate,
+    this.poolLengthMeters = 25,
+    this.targetDistanceMeters = 100,
+    this.targetTime = const Duration(seconds: 90),
+    this.strokeRate = 60,
+    this.breathEveryStrokes = 3,
+    this.cueSettings = const TempoCueSettings(),
+    this.safetyWarningAcknowledged = false,
+    this.isRunning = false,
+    this.beatCount = 0,
+    this.elapsed = Duration.zero,
+    this.flashActive = false,
+    this.lastCueLabel = 'Ready',
+  });
+
+  final TempoMode mode;
+  final int poolLengthMeters;
+  final int targetDistanceMeters;
+  final Duration targetTime;
+  final double strokeRate;
+  final int breathEveryStrokes;
+  final TempoCueSettings cueSettings;
+  final bool safetyWarningAcknowledged;
+  final bool isRunning;
+  final int beatCount;
+  final Duration elapsed;
+  final bool flashActive;
+  final String lastCueLabel;
+
+  TempoCalculator get _calculator => const TempoCalculator();
+
+  Duration get baseStrokeBeatInterval =>
+      _calculator.beatIntervalForStrokeRate(strokeRate);
+
+  Duration get lapSplit => _calculator.splitForDistance(
+        targetTime: targetTime,
+        targetDistanceMeters: targetDistanceMeters,
+        splitDistanceMeters: poolLengthMeters,
+      );
+
+  Duration get pacePer100 => _calculator.pacePer100(
+        targetTime: targetTime,
+        targetDistanceMeters: targetDistanceMeters,
+      );
+
+  Duration get cueInterval {
+    return switch (mode) {
+      TempoMode.strokeRate => baseStrokeBeatInterval,
+      TempoMode.lapPace => lapSplit,
+      TempoMode.breathPattern => Duration(
+          microseconds:
+              baseStrokeBeatInterval.inMicroseconds * breathEveryStrokes,
+        ),
+    };
+  }
+
+  bool get requiresSafetyWarning =>
+      mode == TempoMode.breathPattern &&
+      _calculator.requiresBreathSafetyWarning(breathEveryStrokes);
+
+  TempoTrainerState copyWith({
+    TempoMode? mode,
+    int? poolLengthMeters,
+    int? targetDistanceMeters,
+    Duration? targetTime,
+    double? strokeRate,
+    int? breathEveryStrokes,
+    TempoCueSettings? cueSettings,
+    bool? safetyWarningAcknowledged,
+    bool? isRunning,
+    int? beatCount,
+    Duration? elapsed,
+    bool? flashActive,
+    String? lastCueLabel,
+  }) {
+    return TempoTrainerState(
+      mode: mode ?? this.mode,
+      poolLengthMeters: poolLengthMeters ?? this.poolLengthMeters,
+      targetDistanceMeters: targetDistanceMeters ?? this.targetDistanceMeters,
+      targetTime: targetTime ?? this.targetTime,
+      strokeRate: strokeRate ?? this.strokeRate,
+      breathEveryStrokes: breathEveryStrokes ?? this.breathEveryStrokes,
+      cueSettings: cueSettings ?? this.cueSettings,
+      safetyWarningAcknowledged:
+          safetyWarningAcknowledged ?? this.safetyWarningAcknowledged,
+      isRunning: isRunning ?? this.isRunning,
+      beatCount: beatCount ?? this.beatCount,
+      elapsed: elapsed ?? this.elapsed,
+      flashActive: flashActive ?? this.flashActive,
+      lastCueLabel: lastCueLabel ?? this.lastCueLabel,
+    );
+  }
+
+  TempoTemplate toTemplate({
+    required String id,
+    required String profileId,
+    required String name,
+    required DateTime now,
+  }) {
+    return TempoTemplate(
+      id: id,
+      profileId: profileId,
+      name: name,
+      mode: mode,
+      poolLengthMeters: poolLengthMeters,
+      targetDistanceMeters: targetDistanceMeters,
+      targetTime: targetTime,
+      strokeRate: strokeRate,
+      breathEveryStrokes: breathEveryStrokes,
+      cueSettings: cueSettings,
+      safetyWarningAcknowledged: safetyWarningAcknowledged,
+      createdAt: now,
+      updatedAt: now,
+    );
+  }
+}
+
+class TempoTrainerNotifier extends StateNotifier<TempoTrainerState> {
+  TempoTrainerNotifier(this._cuePlayer) : super(const TempoTrainerState());
+
+  final TempoCuePlayer _cuePlayer;
+  Timer? _timer;
+
+  void configure({
+    required TempoMode mode,
+    required int poolLengthMeters,
+    required int targetDistanceMeters,
+    required Duration targetTime,
+    required double strokeRate,
+    required int breathEveryStrokes,
+    required TempoCueSettings cueSettings,
+    required bool safetyWarningAcknowledged,
+  }) {
+    stop();
+    state = state.copyWith(
+      mode: mode,
+      poolLengthMeters: poolLengthMeters,
+      targetDistanceMeters: targetDistanceMeters,
+      targetTime: targetTime,
+      strokeRate: strokeRate,
+      breathEveryStrokes: breathEveryStrokes,
+      cueSettings: cueSettings,
+      safetyWarningAcknowledged: safetyWarningAcknowledged,
+      lastCueLabel: 'Ready',
+    );
+  }
+
+  void loadTemplate(TempoTemplate template) {
+    configure(
+      mode: template.mode,
+      poolLengthMeters: template.poolLengthMeters,
+      targetDistanceMeters: template.targetDistanceMeters,
+      targetTime: template.targetTime,
+      strokeRate: template.strokeRate,
+      breathEveryStrokes: template.breathEveryStrokes,
+      cueSettings: template.cueSettings,
+      safetyWarningAcknowledged: template.safetyWarningAcknowledged,
+    );
+  }
+
+  void start() {
+    if (state.isRunning) return;
+    state = state.copyWith(isRunning: true, lastCueLabel: 'Running');
+    _playCue();
+    _timer = Timer.periodic(state.cueInterval, (_) => _playCue());
+  }
+
+  void pause() {
+    if (!state.isRunning) return;
+    _timer?.cancel();
+    _timer = null;
+    state = state.copyWith(isRunning: false, lastCueLabel: 'Paused');
+  }
+
+  void stop() {
+    _timer?.cancel();
+    _timer = null;
+    state = state.copyWith(
+      isRunning: false,
+      beatCount: 0,
+      elapsed: Duration.zero,
+      flashActive: false,
+      lastCueLabel: 'Ready',
+    );
+  }
+
+  void clearFlash() {
+    if (!state.flashActive) return;
+    state = state.copyWith(flashActive: false);
+  }
+
+  Future<void> _playCue() async {
+    final nextBeat = state.beatCount + 1;
+    final accentEvery = state.cueSettings.accentEvery;
+    final accent = accentEvery > 0 && nextBeat % accentEvery == 0;
+    state = state.copyWith(
+      beatCount: nextBeat,
+      elapsed: state.elapsed + state.cueInterval,
+      flashActive: state.cueSettings.visualFlash,
+      lastCueLabel: accent ? 'Accent cue' : _cueLabelForMode(state.mode),
+    );
+    await _cuePlayer.playCue(settings: state.cueSettings, accent: accent);
+  }
+
+  String _cueLabelForMode(TempoMode mode) {
+    return switch (mode) {
+      TempoMode.strokeRate => 'Stroke cue',
+      TempoMode.lapPace => 'Wall cue',
+      TempoMode.breathPattern => 'Breathe cue',
+    };
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+}
+
+final tempoTrainerProvider =
+    StateNotifierProvider<TempoTrainerNotifier, TempoTrainerState>(
+  (ref) => TempoTrainerNotifier(ref.read(tempoCuePlayerProvider)),
+);

--- a/lib/features/tempo/presentation/screens/tempo_trainer_screen.dart
+++ b/lib/features/tempo/presentation/screens/tempo_trainer_screen.dart
@@ -232,7 +232,9 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
         ],
       ),
     );
-    controller.dispose();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      controller.dispose();
+    });
     return result;
   }
 

--- a/lib/features/tempo/presentation/screens/tempo_trainer_screen.dart
+++ b/lib/features/tempo/presentation/screens/tempo_trainer_screen.dart
@@ -1,0 +1,814 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/utils/duration_utils.dart';
+import '../../domain/entities/tempo_mode.dart';
+import '../../domain/entities/tempo_session_result.dart';
+import '../../domain/entities/tempo_template.dart';
+import '../../domain/services/tempo_calculator.dart';
+import '../../domain/services/tempo_csv_exporter.dart';
+import '../providers/tempo_template_providers.dart';
+import '../providers/tempo_trainer_provider.dart';
+
+class TempoTrainerScreen extends ConsumerStatefulWidget {
+  const TempoTrainerScreen({super.key});
+
+  @override
+  ConsumerState<TempoTrainerScreen> createState() => _TempoTrainerScreenState();
+}
+
+class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
+  late final TextEditingController _poolLengthController;
+  late final TextEditingController _targetDistanceController;
+  late final TextEditingController _targetTimeController;
+  late final TextEditingController _strokeRateController;
+  late final TextEditingController _breathEveryController;
+  late final TextEditingController _accentEveryController;
+  late final TextEditingController _splitsController;
+  late final TextEditingController _strokeCountsController;
+  late final TextEditingController _rpeController;
+  late final TextEditingController _notesController;
+
+  @override
+  void initState() {
+    super.initState();
+    final state = ref.read(tempoTrainerProvider);
+    _poolLengthController =
+        TextEditingController(text: state.poolLengthMeters.toString());
+    _targetDistanceController =
+        TextEditingController(text: state.targetDistanceMeters.toString());
+    _targetTimeController =
+        TextEditingController(text: _secondsText(state.targetTime));
+    _strokeRateController =
+        TextEditingController(text: state.strokeRate.toStringAsFixed(0));
+    _breathEveryController =
+        TextEditingController(text: state.breathEveryStrokes.toString());
+    _accentEveryController =
+        TextEditingController(text: state.cueSettings.accentEvery.toString());
+    _splitsController = TextEditingController();
+    _strokeCountsController = TextEditingController();
+    _rpeController = TextEditingController();
+    _notesController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _poolLengthController.dispose();
+    _targetDistanceController.dispose();
+    _targetTimeController.dispose();
+    _strokeRateController.dispose();
+    _breathEveryController.dispose();
+    _accentEveryController.dispose();
+    _splitsController.dispose();
+    _strokeCountsController.dispose();
+    _rpeController.dispose();
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  String _secondsText(Duration duration) {
+    final seconds = duration.inMilliseconds / 1000;
+    return seconds == seconds.roundToDouble()
+        ? seconds.toStringAsFixed(0)
+        : seconds.toStringAsFixed(2);
+  }
+
+  void _applyConfig(TempoTrainerState state) {
+    final poolLength = int.tryParse(_poolLengthController.text);
+    final targetDistance = int.tryParse(_targetDistanceController.text);
+    final targetSeconds = double.tryParse(_targetTimeController.text);
+    final strokeRate = double.tryParse(_strokeRateController.text);
+    final breathEvery = int.tryParse(_breathEveryController.text);
+    final accentEvery = int.tryParse(_accentEveryController.text);
+
+    if (poolLength == null ||
+        poolLength <= 0 ||
+        targetDistance == null ||
+        targetDistance <= 0 ||
+        targetSeconds == null ||
+        targetSeconds <= 0 ||
+        strokeRate == null ||
+        strokeRate <= 0 ||
+        breathEvery == null ||
+        breathEvery <= 0 ||
+        accentEvery == null ||
+        accentEvery <= 0) {
+      _showSnack('Enter valid tempo values.');
+      return;
+    }
+
+    final targetTime = Duration(milliseconds: (targetSeconds * 1000).round());
+    ref.read(tempoTrainerProvider.notifier).configure(
+          mode: state.mode,
+          poolLengthMeters: poolLength,
+          targetDistanceMeters: targetDistance,
+          targetTime: targetTime,
+          strokeRate: strokeRate,
+          breathEveryStrokes: breathEvery,
+          cueSettings: state.cueSettings.copyWith(accentEvery: accentEvery),
+          safetyWarningAcknowledged: state.safetyWarningAcknowledged,
+        );
+    FocusScope.of(context).unfocus();
+  }
+
+  void _syncControllers(TempoTrainerState state) {
+    _poolLengthController.text = state.poolLengthMeters.toString();
+    _targetDistanceController.text = state.targetDistanceMeters.toString();
+    _targetTimeController.text = _secondsText(state.targetTime);
+    _strokeRateController.text = state.strokeRate.toStringAsFixed(0);
+    _breathEveryController.text = state.breathEveryStrokes.toString();
+    _accentEveryController.text = state.cueSettings.accentEvery.toString();
+  }
+
+  Future<void> _saveTemplate() async {
+    final name = await _promptForName(
+      title: 'Save tempo template',
+      label: 'Template name',
+    );
+    if (name == null || name.trim().isEmpty) return;
+    final saved = await ref
+        .read(tempoTemplatesProvider.notifier)
+        .saveFromState(name, ref.read(tempoTrainerProvider));
+    if (!mounted) return;
+    _showSnack('Saved ${saved.name}.');
+  }
+
+  Future<void> _saveSessionResult(TempoTrainerState state) async {
+    final splits = _parseDurationList(_splitsController.text);
+    if (splits.isEmpty) {
+      _showSnack('Enter at least one actual split in seconds.');
+      return;
+    }
+    final strokeCounts = _parseIntList(_strokeCountsController.text);
+    final rpe = _rpeController.text.trim().isEmpty
+        ? null
+        : int.tryParse(_rpeController.text);
+    if (rpe != null && (rpe < 1 || rpe > 10)) {
+      _showSnack('RPE must be between 1 and 10.');
+      return;
+    }
+
+    final result =
+        await ref.read(tempoSessionResultsProvider.notifier).saveResult(
+              trainer: state,
+              actualSplits: splits,
+              strokeCounts: strokeCounts,
+              rpe: rpe,
+              notes: _notesController.text,
+            );
+    if (!mounted) return;
+    _showSnack('Saved tempo result with ${result.actualSplits.length} splits.');
+  }
+
+  Future<void> _copyCsv(TempoTrainerState state) async {
+    final splits = _parseDurationList(_splitsController.text);
+    if (splits.isEmpty) {
+      _showSnack('Enter actual splits before exporting CSV.');
+      return;
+    }
+    final result = TempoSessionResult(
+      id: 'preview',
+      mode: state.mode,
+      startedAt: DateTime.now().toUtc(),
+      completedAt: DateTime.now().toUtc(),
+      targetDistanceMeters: state.targetDistanceMeters,
+      poolLengthMeters: state.poolLengthMeters,
+      targetTime: state.targetTime,
+      targetStrokeRate: state.strokeRate,
+      actualSplits: splits,
+      strokeCounts: _parseIntList(_strokeCountsController.text),
+    );
+    final csv = const TempoCsvExporter().exportSession(result);
+    await Clipboard.setData(ClipboardData(text: csv));
+    if (!mounted) return;
+    _showSnack('Copied tempo CSV.');
+  }
+
+  List<Duration> _parseDurationList(String value) {
+    return value
+        .split(',')
+        .map((item) => double.tryParse(item.trim()))
+        .whereType<double>()
+        .where((seconds) => seconds > 0)
+        .map((seconds) => Duration(milliseconds: (seconds * 1000).round()))
+        .toList();
+  }
+
+  List<int> _parseIntList(String value) {
+    return value
+        .split(',')
+        .map((item) => int.tryParse(item.trim()))
+        .whereType<int>()
+        .where((count) => count > 0)
+        .toList();
+  }
+
+  Future<String?> _promptForName({
+    required String title,
+    required String label,
+  }) async {
+    final controller = TextEditingController();
+    final result = await showDialog<String>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: Text(title),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: InputDecoration(labelText: label),
+          textInputAction: TextInputAction.done,
+          onSubmitted: (value) => Navigator.of(context).pop(value),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(controller.text),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    return result;
+  }
+
+  void _showSnack(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(tempoTrainerProvider);
+    final notifier = ref.read(tempoTrainerProvider.notifier);
+    final templatesAsync = ref.watch(tempoTemplatesProvider);
+    final resultsAsync = ref.watch(tempoSessionResultsProvider);
+
+    ref.listen(tempoTrainerProvider, (_, next) {
+      if (!next.flashActive) return;
+      Future<void>.delayed(const Duration(milliseconds: 120), () {
+        if (!mounted) return;
+        ref.read(tempoTrainerProvider.notifier).clearFlash();
+      });
+    });
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Tempo Trainer')),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            _ModeSelector(
+              value: state.mode,
+              enabled: !state.isRunning,
+              onChanged: (mode) {
+                ref.read(tempoTrainerProvider.notifier).configure(
+                      mode: mode,
+                      poolLengthMeters: state.poolLengthMeters,
+                      targetDistanceMeters: state.targetDistanceMeters,
+                      targetTime: state.targetTime,
+                      strokeRate: state.strokeRate,
+                      breathEveryStrokes: state.breathEveryStrokes,
+                      cueSettings: state.cueSettings,
+                      safetyWarningAcknowledged:
+                          state.safetyWarningAcknowledged,
+                    );
+              },
+            ),
+            const SizedBox(height: 16),
+            _TempoConfigPanel(
+              state: state,
+              poolLengthController: _poolLengthController,
+              targetDistanceController: _targetDistanceController,
+              targetTimeController: _targetTimeController,
+              strokeRateController: _strokeRateController,
+              breathEveryController: _breathEveryController,
+              accentEveryController: _accentEveryController,
+              onApply: () => _applyConfig(state),
+              onCueSettingsChanged: (settings) {
+                ref.read(tempoTrainerProvider.notifier).configure(
+                      mode: state.mode,
+                      poolLengthMeters: state.poolLengthMeters,
+                      targetDistanceMeters: state.targetDistanceMeters,
+                      targetTime: state.targetTime,
+                      strokeRate: state.strokeRate,
+                      breathEveryStrokes: state.breathEveryStrokes,
+                      cueSettings: settings,
+                      safetyWarningAcknowledged:
+                          state.safetyWarningAcknowledged,
+                    );
+              },
+              onSafetyChanged: (value) {
+                ref.read(tempoTrainerProvider.notifier).configure(
+                      mode: state.mode,
+                      poolLengthMeters: state.poolLengthMeters,
+                      targetDistanceMeters: state.targetDistanceMeters,
+                      targetTime: state.targetTime,
+                      strokeRate: state.strokeRate,
+                      breathEveryStrokes: state.breathEveryStrokes,
+                      cueSettings: state.cueSettings,
+                      safetyWarningAcknowledged: value,
+                    );
+              },
+            ),
+            const SizedBox(height: 16),
+            _RunPanel(
+              state: state,
+              onStartPause: state.isRunning ? notifier.pause : notifier.start,
+              onStop: notifier.stop,
+            ),
+            const SizedBox(height: 16),
+            _TemplatePanel(
+              templatesAsync: templatesAsync,
+              enabled: !state.isRunning,
+              onSave: _saveTemplate,
+              onLoad: (template) {
+                notifier.loadTemplate(template);
+                _syncControllers(ref.read(tempoTrainerProvider));
+                _showSnack('Loaded ${template.name}.');
+              },
+              onDelete: (id) =>
+                  ref.read(tempoTemplatesProvider.notifier).deleteTemplate(id),
+            ),
+            const SizedBox(height: 16),
+            _ResultPanel(
+              state: state,
+              resultsAsync: resultsAsync,
+              splitsController: _splitsController,
+              strokeCountsController: _strokeCountsController,
+              rpeController: _rpeController,
+              notesController: _notesController,
+              onSave: () => _saveSessionResult(state),
+              onCopyCsv: () => _copyCsv(state),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ModeSelector extends StatelessWidget {
+  const _ModeSelector({
+    required this.value,
+    required this.enabled,
+    required this.onChanged,
+  });
+
+  final TempoMode value;
+  final bool enabled;
+  final ValueChanged<TempoMode> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SegmentedButton<TempoMode>(
+      segments: [
+        for (final mode in TempoMode.values)
+          ButtonSegment<TempoMode>(
+            value: mode,
+            icon: Icon(_iconForMode(mode)),
+            label: Text(mode.label),
+          ),
+      ],
+      selected: {value},
+      onSelectionChanged:
+          enabled ? (selected) => onChanged(selected.single) : null,
+    );
+  }
+
+  IconData _iconForMode(TempoMode mode) {
+    return switch (mode) {
+      TempoMode.strokeRate => Icons.speed,
+      TempoMode.lapPace => Icons.flag_outlined,
+      TempoMode.breathPattern => Icons.air,
+    };
+  }
+}
+
+class _TempoConfigPanel extends StatelessWidget {
+  const _TempoConfigPanel({
+    required this.state,
+    required this.poolLengthController,
+    required this.targetDistanceController,
+    required this.targetTimeController,
+    required this.strokeRateController,
+    required this.breathEveryController,
+    required this.accentEveryController,
+    required this.onApply,
+    required this.onCueSettingsChanged,
+    required this.onSafetyChanged,
+  });
+
+  final TempoTrainerState state;
+  final TextEditingController poolLengthController;
+  final TextEditingController targetDistanceController;
+  final TextEditingController targetTimeController;
+  final TextEditingController strokeRateController;
+  final TextEditingController breathEveryController;
+  final TextEditingController accentEveryController;
+  final VoidCallback onApply;
+  final ValueChanged<TempoCueSettings> onCueSettingsChanged;
+  final ValueChanged<bool> onSafetyChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final cue = state.cueSettings;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Session Setup',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: [
+                _NumberField(
+                  controller: poolLengthController,
+                  label: 'Pool m',
+                  enabled: !state.isRunning,
+                ),
+                _NumberField(
+                  controller: targetDistanceController,
+                  label: 'Target m',
+                  enabled: !state.isRunning,
+                ),
+                _NumberField(
+                  controller: targetTimeController,
+                  label: 'Target sec',
+                  enabled: !state.isRunning,
+                  decimal: true,
+                ),
+                _NumberField(
+                  controller: strokeRateController,
+                  label: 'Stroke/min',
+                  enabled: !state.isRunning,
+                  decimal: true,
+                ),
+                _NumberField(
+                  controller: breathEveryController,
+                  label: 'Breathe every',
+                  enabled: !state.isRunning,
+                ),
+                _NumberField(
+                  controller: accentEveryController,
+                  label: 'Accent every',
+                  enabled: !state.isRunning,
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 4,
+              children: [
+                FilterChip(
+                  label: const Text('Sound'),
+                  selected: cue.audible,
+                  onSelected: state.isRunning
+                      ? null
+                      : (value) => onCueSettingsChanged(
+                            cue.copyWith(audible: value),
+                          ),
+                ),
+                FilterChip(
+                  label: const Text('Vibration'),
+                  selected: cue.vibration,
+                  onSelected: state.isRunning
+                      ? null
+                      : (value) => onCueSettingsChanged(
+                            cue.copyWith(vibration: value),
+                          ),
+                ),
+                FilterChip(
+                  label: const Text('Visual flash'),
+                  selected: cue.visualFlash,
+                  onSelected: state.isRunning
+                      ? null
+                      : (value) => onCueSettingsChanged(
+                            cue.copyWith(visualFlash: value),
+                          ),
+                ),
+                FilterChip(
+                  label: const Text('Voice alert'),
+                  selected: cue.spoken,
+                  onSelected: state.isRunning
+                      ? null
+                      : (value) => onCueSettingsChanged(
+                            cue.copyWith(spoken: value),
+                          ),
+                ),
+              ],
+            ),
+            if (state.requiresSafetyWarning) ...[
+              const SizedBox(height: 12),
+              CheckboxListTile(
+                contentPadding: EdgeInsets.zero,
+                value: state.safetyWarningAcknowledged,
+                onChanged: state.isRunning
+                    ? null
+                    : (value) => onSafetyChanged(value ?? false),
+                title: const Text('Breath safety acknowledged'),
+                subtitle: const Text(
+                  'Breath cues are for rhythm only. Do not use this for '
+                  'max breath holds, underwater distance challenges, or '
+                  'unsupervised hypoxic sets.',
+                ),
+              ),
+            ],
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton.icon(
+                onPressed: state.isRunning ? null : onApply,
+                icon: const Icon(Icons.check),
+                label: const Text('Apply'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RunPanel extends StatelessWidget {
+  const _RunPanel({
+    required this.state,
+    required this.onStartPause,
+    required this.onStop,
+  });
+
+  final TempoTrainerState state;
+  final VoidCallback onStartPause;
+  final VoidCallback onStop;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    const calculator = TempoCalculator();
+    final pace = DurationUtils.formatDurationWithCentiseconds(
+      state.pacePer100,
+    );
+    final split = DurationUtils.formatDurationWithCentiseconds(state.lapSplit);
+    final interval = DurationUtils.formatDurationWithCentiseconds(
+      state.cueInterval,
+    );
+
+    return Card(
+      color: state.flashActive
+          ? colorScheme.primaryContainer
+          : colorScheme.surface,
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          children: [
+            Text(
+              state.lastCueLabel,
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Cue $interval · Split $split · Pace $pace/100m',
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Beat ${state.beatCount} · '
+              '${DurationUtils.formatDuration(state.elapsed)} elapsed',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            if (state.mode == TempoMode.strokeRate) ...[
+              const SizedBox(height: 8),
+              Text(
+                '${calculator.strokeRateForBeatInterval(state.cueInterval).toStringAsFixed(1)} strokes/min',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                OutlinedButton.icon(
+                  onPressed: onStop,
+                  icon: const Icon(Icons.stop),
+                  label: const Text('Reset'),
+                ),
+                const SizedBox(width: 12),
+                FilledButton.icon(
+                  onPressed: state.requiresSafetyWarning &&
+                          !state.safetyWarningAcknowledged
+                      ? null
+                      : onStartPause,
+                  icon: Icon(
+                    state.isRunning ? Icons.pause : Icons.play_arrow,
+                  ),
+                  label: Text(state.isRunning ? 'Pause' : 'Start'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TemplatePanel extends StatelessWidget {
+  const _TemplatePanel({
+    required this.templatesAsync,
+    required this.enabled,
+    required this.onSave,
+    required this.onLoad,
+    required this.onDelete,
+  });
+
+  final AsyncValue<List<TempoTemplate>> templatesAsync;
+  final bool enabled;
+  final VoidCallback onSave;
+  final ValueChanged<TempoTemplate> onLoad;
+  final Future<void> Function(String) onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final templates = templatesAsync.valueOrNull ?? const <TempoTemplate>[];
+    return Row(
+      children: [
+        Expanded(
+          child: PopupMenuButton<TempoTemplate>(
+            tooltip: 'Load tempo template',
+            enabled: enabled && templates.isNotEmpty,
+            onSelected: onLoad,
+            itemBuilder: (_) => [
+              for (final template in templates)
+                PopupMenuItem<TempoTemplate>(
+                  value: template,
+                  child: Text('${template.name} · ${template.mode.label}'),
+                ),
+            ],
+            child: IgnorePointer(
+              child: OutlinedButton.icon(
+                onPressed: enabled && templates.isNotEmpty ? () {} : null,
+                icon: const Icon(Icons.folder_open_outlined),
+                label: Text(
+                  templates.isEmpty ? 'No Templates' : 'Load Template',
+                ),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        FilledButton.tonalIcon(
+          onPressed: enabled ? onSave : null,
+          icon: const Icon(Icons.save_outlined),
+          label: const Text('Save'),
+        ),
+        if (templates.isNotEmpty) ...[
+          const SizedBox(width: 8),
+          PopupMenuButton<String>(
+            tooltip: 'Delete tempo template',
+            enabled: enabled,
+            icon: const Icon(Icons.delete_outline),
+            onSelected: onDelete,
+            itemBuilder: (_) => [
+              for (final template in templates)
+                PopupMenuItem<String>(
+                  value: template.id,
+                  child: Text('Delete ${template.name}'),
+                ),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _ResultPanel extends StatelessWidget {
+  const _ResultPanel({
+    required this.state,
+    required this.resultsAsync,
+    required this.splitsController,
+    required this.strokeCountsController,
+    required this.rpeController,
+    required this.notesController,
+    required this.onSave,
+    required this.onCopyCsv,
+  });
+
+  final TempoTrainerState state;
+  final AsyncValue<List<TempoSessionResult>> resultsAsync;
+  final TextEditingController splitsController;
+  final TextEditingController strokeCountsController;
+  final TextEditingController rpeController;
+  final TextEditingController notesController;
+  final VoidCallback onSave;
+  final VoidCallback onCopyCsv;
+
+  @override
+  Widget build(BuildContext context) {
+    final resultCount = resultsAsync.valueOrNull?.length ?? 0;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Session Result',
+                style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 12),
+            TextField(
+              controller: splitsController,
+              decoration: const InputDecoration(
+                labelText: 'Actual splits sec',
+                hintText: '22.5, 22.9, 23.1, 22.8',
+              ),
+              keyboardType: TextInputType.text,
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: strokeCountsController,
+              decoration: const InputDecoration(
+                labelText: 'Stroke counts',
+                hintText: '18, 19, 20, 20',
+              ),
+              keyboardType: TextInputType.text,
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: rpeController,
+              decoration: const InputDecoration(labelText: 'RPE 1-10'),
+              keyboardType: TextInputType.number,
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: notesController,
+              decoration: const InputDecoration(labelText: 'Notes'),
+              minLines: 1,
+              maxLines: 3,
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    '$resultCount saved tempo sessions',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ),
+                OutlinedButton.icon(
+                  onPressed: onCopyCsv,
+                  icon: const Icon(Icons.copy),
+                  label: const Text('CSV'),
+                ),
+                const SizedBox(width: 8),
+                FilledButton.icon(
+                  onPressed: state.isRunning ? null : onSave,
+                  icon: const Icon(Icons.done),
+                  label: const Text('Save Result'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _NumberField extends StatelessWidget {
+  const _NumberField({
+    required this.controller,
+    required this.label,
+    required this.enabled,
+    this.decimal = false,
+  });
+
+  final TextEditingController controller;
+  final String label;
+  final bool enabled;
+  final bool decimal;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 150,
+      child: TextField(
+        controller: controller,
+        enabled: enabled,
+        decoration: InputDecoration(labelText: label),
+        keyboardType: TextInputType.numberWithOptions(decimal: decimal),
+      ),
+    );
+  }
+}

--- a/test/core/sync/sync_payloads_test.dart
+++ b/test/core/sync/sync_payloads_test.dart
@@ -9,6 +9,9 @@ import 'package:rep_swim/features/race/domain/entities/qualification_standard.da
 import 'package:rep_swim/features/race/domain/entities/race_time.dart';
 import 'package:rep_swim/features/swim/domain/entities/lap.dart';
 import 'package:rep_swim/features/swim/domain/entities/swim_session.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_mode.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_session_result.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_template.dart';
 import 'package:rep_swim/features/templates/domain/entities/dryland_routine_template.dart';
 import 'package:rep_swim/features/templates/domain/entities/interval_template.dart';
 
@@ -142,6 +145,85 @@ void main() {
         (drylandRoutineTemplatePayload(routine)['exercises'] as List).single,
         containsPair('name', 'Plank'),
       );
+    });
+
+    test('serializes tempo templates and session results', () {
+      final template = TempoTemplate(
+        id: 'tempo-template-1',
+        profileId: 'profile-1',
+        name: 'Tempo 50s',
+        mode: TempoMode.strokeRate,
+        poolLengthMeters: 25,
+        targetDistanceMeters: 100,
+        targetTime: const Duration(seconds: 88),
+        strokeRate: 72,
+        breathEveryStrokes: 3,
+        cueSettings: const TempoCueSettings(
+          audible: true,
+          vibration: true,
+          visualFlash: true,
+          spoken: false,
+          accentEvery: 4,
+        ),
+        safetyWarningAcknowledged: false,
+        createdAt: DateTime.utc(2024),
+        updatedAt: DateTime.utc(2024, 1, 2),
+      );
+      final result = TempoSessionResult(
+        id: 'tempo-result-1',
+        profileId: 'profile-1',
+        templateId: template.id,
+        mode: TempoMode.strokeRate,
+        startedAt: DateTime.utc(2024, 1, 2),
+        completedAt: DateTime.utc(2024, 1, 2, 0, 2),
+        targetDistanceMeters: 100,
+        poolLengthMeters: 25,
+        targetTime: const Duration(seconds: 88),
+        targetStrokeRate: 72,
+        actualSplits: const [
+          Duration(milliseconds: 22000),
+          Duration(milliseconds: 22500),
+        ],
+        strokeCounts: const [18, 19],
+        rpe: 7,
+        notes: 'Held rhythm',
+      );
+
+      expect(tempoTemplatePayload(template), {
+        'id': 'tempo-template-1',
+        'profileId': 'profile-1',
+        'name': 'Tempo 50s',
+        'mode': 'strokeRate',
+        'poolLengthMeters': 25,
+        'targetDistanceMeters': 100,
+        'targetTimeMilliseconds': 88000,
+        'strokeRate': 72,
+        'breathEveryStrokes': 3,
+        'audibleEnabled': true,
+        'vibrationEnabled': true,
+        'visualFlashEnabled': true,
+        'spokenEnabled': false,
+        'accentEvery': 4,
+        'safetyWarningAcknowledged': false,
+        'createdAt': 1704067200000,
+        'updatedAt': 1704153600000,
+      });
+      expect(tempoSessionResultPayload(result), {
+        'id': 'tempo-result-1',
+        'profileId': 'profile-1',
+        'templateId': 'tempo-template-1',
+        'mode': 'strokeRate',
+        'startedAt': 1704153600000,
+        'completedAt': 1704153720000,
+        'targetDistanceMeters': 100,
+        'poolLengthMeters': 25,
+        'targetTimeMilliseconds': 88000,
+        'targetStrokeRate': 72,
+        'actualSplitsMilliseconds': [22000, 22500],
+        'strokeCounts': [18, 19],
+        'rpe': 7,
+        'notes': 'Held rhythm',
+      });
     });
 
     test('serializes race times with course and centiseconds', () {

--- a/test/database/dao_integration_test.dart
+++ b/test/database/dao_integration_test.dart
@@ -18,6 +18,9 @@ import 'package:rep_swim/features/race/domain/entities/qualification_standard.da
 import 'package:rep_swim/features/race/domain/entities/race_time.dart';
 import 'package:rep_swim/features/swim/domain/entities/lap.dart';
 import 'package:rep_swim/features/swim/domain/entities/swim_session.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_mode.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_session_result.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_template.dart';
 import 'package:rep_swim/features/templates/domain/entities/dryland_routine_template.dart';
 
 void main() {
@@ -178,6 +181,64 @@ void main() {
         await dao.getDrylandRoutineExercises('template-1', 'profile-1'),
         isEmpty,
       );
+    });
+
+    test('tempo templates and session results persist offline', () async {
+      final dao = TrainingTemplateDao(appDb);
+      final now = DateTime.utc(2024);
+      final template = TempoTemplate(
+        id: 'tempo-template-1',
+        profileId: 'profile-1',
+        name: 'CSS 100s',
+        mode: TempoMode.lapPace,
+        poolLengthMeters: 25,
+        targetDistanceMeters: 100,
+        targetTime: const Duration(seconds: 88),
+        strokeRate: 72,
+        breathEveryStrokes: 3,
+        cueSettings: const TempoCueSettings(
+          audible: true,
+          vibration: true,
+          visualFlash: true,
+          spoken: false,
+          accentEvery: 4,
+        ),
+        safetyWarningAcknowledged: false,
+        createdAt: now,
+        updatedAt: now,
+      );
+
+      await dao.insertTempoTemplate(template);
+      final templates = await dao.getTempoTemplates('profile-1');
+      expect(templates.single.name, 'CSS 100s');
+      expect(templates.single.cueSettings.vibration, isTrue);
+
+      final result = TempoSessionResult(
+        id: 'tempo-result-1',
+        profileId: 'profile-1',
+        templateId: template.id,
+        mode: TempoMode.lapPace,
+        startedAt: now,
+        completedAt: now.add(const Duration(minutes: 2)),
+        targetDistanceMeters: 100,
+        poolLengthMeters: 25,
+        targetTime: const Duration(seconds: 88),
+        targetStrokeRate: 72,
+        actualSplits: const [
+          Duration(milliseconds: 22000),
+          Duration(milliseconds: 22400),
+        ],
+        strokeCounts: const [18, 19],
+        rpe: 7,
+        notes: 'Held rhythm',
+      );
+
+      await dao.insertTempoSessionResult(result);
+      final results = await dao.getTempoSessionResults('profile-1');
+      expect(results.single.templateId, template.id);
+      expect(results.single.actualSplits.last.inMilliseconds, 22400);
+      expect(results.single.strokeCounts, [18, 19]);
+      expect(results.single.notes, 'Held rhythm');
     });
 
     test('sync queue preserves insertion order and increments retry count',

--- a/test/database/dao_integration_test.dart
+++ b/test/database/dao_integration_test.dart
@@ -209,9 +209,17 @@ void main() {
       );
 
       await dao.insertTempoTemplate(template);
+      await dao.insertTempoTemplate(
+        template.copyWith(
+          id: 'tempo-template-2',
+          profileId: 'profile-2',
+          name: 'Other swimmer tempo',
+        ),
+      );
       final templates = await dao.getTempoTemplates('profile-1');
       expect(templates.single.name, 'CSS 100s');
       expect(templates.single.cueSettings.vibration, isTrue);
+      expect(await dao.getTempoTemplates('profile-2'), hasLength(1));
 
       final result = TempoSessionResult(
         id: 'tempo-result-1',
@@ -234,11 +242,26 @@ void main() {
       );
 
       await dao.insertTempoSessionResult(result);
+      await dao.insertTempoSessionResult(
+        TempoSessionResult(
+          id: 'tempo-result-2',
+          profileId: 'profile-2',
+          mode: TempoMode.lapPace,
+          startedAt: now,
+          targetDistanceMeters: 100,
+          poolLengthMeters: 25,
+          targetTime: const Duration(seconds: 88),
+          targetStrokeRate: 72,
+          actualSplits: const [Duration(milliseconds: 22000)],
+          strokeCounts: const [18],
+        ),
+      );
       final results = await dao.getTempoSessionResults('profile-1');
       expect(results.single.templateId, template.id);
       expect(results.single.actualSplits.last.inMilliseconds, 22400);
       expect(results.single.strokeCounts, [18, 19]);
       expect(results.single.notes, 'Held rhythm');
+      expect(await dao.getTempoSessionResults('profile-2'), hasLength(1));
     });
 
     test('sync queue preserves insertion order and increments retry count',

--- a/test/database/migration_test.dart
+++ b/test/database/migration_test.dart
@@ -11,7 +11,7 @@ void main() {
   });
 
   group('database migrations', () {
-    for (final oldVersion in [1, 3, 4, 5, 7, 8, 9, 10]) {
+    for (final oldVersion in [1, 3, 4, 5, 7, 8, 9, 10, 11]) {
       test('upgrades version $oldVersion to current schema', () async {
         final path = p.join(
           Directory.systemTemp.path,
@@ -38,6 +38,8 @@ void main() {
         expect(await _hasTable(db, 'race_times'), isTrue);
         expect(await _hasTable(db, 'qualification_standards'), isTrue);
         expect(await _hasTable(db, 'meet_qualification_standards'), isTrue);
+        expect(await _hasTable(db, 'tempo_templates'), isTrue);
+        expect(await _hasTable(db, 'tempo_session_results'), isTrue);
         expect(await _hasColumn(db, 'swimmer_profiles', 'photo_uri'), isTrue);
         expect(
           await _hasColumn(db, 'swimmer_profiles', 'preferred_strokes_json'),
@@ -249,6 +251,29 @@ Future<void> _createOldSchema(Database db, int version) async {
         bronze_centiseconds INTEGER NOT NULL,
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
+      )
+    ''');
+  }
+  if (version >= 11) {
+    await db.execute('''
+      CREATE TABLE meet_qualification_standards (
+        id TEXT PRIMARY KEY,
+        source_name TEXT NOT NULL,
+        sex TEXT,
+        age_group_label TEXT NOT NULL,
+        min_age INTEGER,
+        max_age INTEGER,
+        is_open INTEGER NOT NULL,
+        distance INTEGER,
+        stroke TEXT,
+        course_type TEXT NOT NULL,
+        qualifying_centiseconds INTEGER,
+        mc_points INTEGER,
+        is_relay INTEGER NOT NULL,
+        relay_event TEXT,
+        valid_from INTEGER NOT NULL,
+        competition_start INTEGER NOT NULL,
+        competition_end INTEGER NOT NULL
       )
     ''');
   }

--- a/test/features/tempo/tempo_calculator_test.dart
+++ b/test/features/tempo/tempo_calculator_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/tempo/domain/services/tempo_calculator.dart';
+
+void main() {
+  group('TempoCalculator', () {
+    const calculator = TempoCalculator();
+
+    test('converts stroke rate to beat interval and back', () {
+      final interval = calculator.beatIntervalForStrokeRate(60);
+
+      expect(interval, const Duration(seconds: 1));
+      expect(calculator.strokeRateForBeatInterval(interval), 60);
+    });
+
+    test('calculates split and pace targets', () {
+      const targetTime = Duration(seconds: 88);
+
+      expect(
+        calculator.splitForDistance(
+          targetTime: targetTime,
+          targetDistanceMeters: 100,
+          splitDistanceMeters: 25,
+        ),
+        const Duration(seconds: 22),
+      );
+      expect(
+        calculator.pacePer100(
+          targetTime: const Duration(minutes: 5, seconds: 40),
+          targetDistanceMeters: 400,
+        ),
+        const Duration(seconds: 85),
+      );
+    });
+
+    test('compares actual splits against a target', () {
+      final results = calculator.compareSplits(
+        actualSplits: const [
+          Duration(milliseconds: 22500),
+          Duration(milliseconds: 23200),
+        ],
+        targetSplit: const Duration(seconds: 23),
+        strokeCounts: const [18, 20],
+      );
+
+      expect(results.first.error, const Duration(milliseconds: -500));
+      expect(results.first.isOnPace, isTrue);
+      expect(results.last.strokeCount, 20);
+      expect(
+        calculator.averageSplitError(results),
+        const Duration(milliseconds: -150),
+      );
+    });
+
+    test('flags high breath intervals for safety acknowledgement', () {
+      expect(calculator.requiresBreathSafetyWarning(4), isFalse);
+      expect(calculator.requiresBreathSafetyWarning(5), isTrue);
+    });
+  });
+}

--- a/test/features/tempo/tempo_csv_exporter_test.dart
+++ b/test/features/tempo/tempo_csv_exporter_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_mode.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_session_result.dart';
+import 'package:rep_swim/features/tempo/domain/services/tempo_csv_exporter.dart';
+
+void main() {
+  group('TempoCsvExporter', () {
+    test('exports split errors and stroke counts', () {
+      final csv = const TempoCsvExporter().exportSession(
+        TempoSessionResult(
+          id: 'tempo-1',
+          mode: TempoMode.lapPace,
+          startedAt: DateTime.utc(2024),
+          targetDistanceMeters: 100,
+          poolLengthMeters: 25,
+          targetTime: const Duration(seconds: 88),
+          targetStrokeRate: 70,
+          actualSplits: const [
+            Duration(milliseconds: 22000),
+            Duration(milliseconds: 22500),
+          ],
+          strokeCounts: const [18, 19],
+        ),
+      );
+
+      expect(
+        csv,
+        contains('session_id,mode,split_index,target_split_ms'),
+      );
+      expect(csv, contains('tempo-1,lapPace,1,22000,22000,0,18'));
+      expect(csv, contains('tempo-1,lapPace,2,22000,22500,500,19'));
+    });
+  });
+}

--- a/test/features/tempo/tempo_template_providers_test.dart
+++ b/test/features/tempo/tempo_template_providers_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:rep_swim/core/sync/sync_mode.dart';
+import 'package:rep_swim/database/daos/sync_queue_dao.dart';
+import 'package:rep_swim/database/daos/training_template_dao.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_mode.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_session_result.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_template.dart';
+import 'package:rep_swim/features/tempo/presentation/providers/tempo_template_providers.dart';
+import 'package:rep_swim/features/tempo/presentation/providers/tempo_trainer_provider.dart';
+
+class _MockTrainingTemplateDao extends Mock implements TrainingTemplateDao {}
+
+class _MockSyncQueueDao extends Mock implements SyncQueueDao {}
+
+TempoTemplate _tempoTemplate() {
+  return TempoTemplate(
+    id: 'tempo-template-1',
+    profileId: 'profile-1',
+    name: 'Tempo 50s',
+    mode: TempoMode.strokeRate,
+    poolLengthMeters: 25,
+    targetDistanceMeters: 100,
+    targetTime: const Duration(seconds: 88),
+    strokeRate: 72,
+    breathEveryStrokes: 3,
+    cueSettings: const TempoCueSettings(vibration: true),
+    safetyWarningAcknowledged: false,
+    createdAt: DateTime.utc(2024),
+    updatedAt: DateTime.utc(2024),
+  );
+}
+
+TempoSessionResult _tempoResult() {
+  return TempoSessionResult(
+    id: 'tempo-result-1',
+    profileId: 'profile-1',
+    mode: TempoMode.lapPace,
+    startedAt: DateTime.utc(2024),
+    targetDistanceMeters: 100,
+    poolLengthMeters: 25,
+    targetTime: const Duration(seconds: 88),
+    targetStrokeRate: 72,
+    actualSplits: const [Duration(seconds: 22)],
+    strokeCounts: const [18],
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_tempoTemplate());
+    registerFallbackValue(_tempoResult());
+    registerFallbackValue(SyncOperation.create);
+    registerFallbackValue(<String, Object?>{});
+  });
+
+  group('TempoTemplatesNotifier', () {
+    test('saves trainer state as a reusable template and queues sync',
+        () async {
+      final dao = _MockTrainingTemplateDao();
+      final queue = _MockSyncQueueDao();
+      when(() => dao.getTempoTemplates(any()))
+          .thenAnswer((_) async => [_tempoTemplate()]);
+      when(() => dao.insertTempoTemplate(any())).thenAnswer((_) async {});
+      when(
+        () => queue.enqueue(
+          profileId: any(named: 'profileId'),
+          entityType: any(named: 'entityType'),
+          entityId: any(named: 'entityId'),
+          operation: any(named: 'operation'),
+          payload: any(named: 'payload'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final notifier = TempoTemplatesNotifier(
+        dao,
+        'profile-1',
+        syncQueueDao: queue,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final saved = await notifier.saveFromState(
+        '  CSS tempo  ',
+        const TempoTrainerState(
+          mode: TempoMode.lapPace,
+          poolLengthMeters: 25,
+          targetDistanceMeters: 100,
+          targetTime: Duration(seconds: 88),
+          strokeRate: 72,
+          cueSettings: TempoCueSettings(vibration: true),
+        ),
+      );
+
+      expect(saved.name, 'CSS tempo');
+      expect(saved.mode, TempoMode.lapPace);
+      expect(saved.cueSettings.vibration, isTrue);
+      verify(() => dao.insertTempoTemplate(any())).called(1);
+      verify(
+        () => queue.enqueue(
+          profileId: 'profile-1',
+          entityType: 'tempo_template',
+          entityId: saved.id,
+          operation: SyncOperation.create,
+          payload: any(named: 'payload'),
+        ),
+      ).called(1);
+      verify(() => dao.getTempoTemplates('profile-1'))
+          .called(greaterThanOrEqualTo(2));
+    });
+
+    test('deletes templates by profile and queues deletion', () async {
+      final dao = _MockTrainingTemplateDao();
+      final queue = _MockSyncQueueDao();
+      when(() => dao.getTempoTemplates(any())).thenAnswer((_) async => []);
+      when(() => dao.deleteTempoTemplate(any(), any()))
+          .thenAnswer((_) async {});
+      when(
+        () => queue.enqueue(
+          profileId: any(named: 'profileId'),
+          entityType: any(named: 'entityType'),
+          entityId: any(named: 'entityId'),
+          operation: any(named: 'operation'),
+          payload: any(named: 'payload'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final notifier = TempoTemplatesNotifier(
+        dao,
+        'profile-1',
+        syncQueueDao: queue,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      await notifier.deleteTemplate('tempo-template-1');
+
+      verify(() => dao.deleteTempoTemplate('tempo-template-1', 'profile-1'))
+          .called(1);
+      verify(
+        () => queue.enqueue(
+          profileId: 'profile-1',
+          entityType: 'tempo_template',
+          entityId: 'tempo-template-1',
+          operation: SyncOperation.delete,
+          payload: any(named: 'payload'),
+        ),
+      ).called(1);
+    });
+  });
+
+  group('TempoSessionResultsNotifier', () {
+    test('saves session result with splits, notes, and sync payload', () async {
+      final dao = _MockTrainingTemplateDao();
+      final queue = _MockSyncQueueDao();
+      when(() => dao.getTempoSessionResults(any()))
+          .thenAnswer((_) async => [_tempoResult()]);
+      when(() => dao.insertTempoSessionResult(any())).thenAnswer((_) async {});
+      when(
+        () => queue.enqueue(
+          profileId: any(named: 'profileId'),
+          entityType: any(named: 'entityType'),
+          entityId: any(named: 'entityId'),
+          operation: any(named: 'operation'),
+          payload: any(named: 'payload'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final notifier = TempoSessionResultsNotifier(
+        dao,
+        'profile-1',
+        syncQueueDao: queue,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final saved = await notifier.saveResult(
+        trainer: const TempoTrainerState(
+          mode: TempoMode.lapPace,
+          poolLengthMeters: 25,
+          targetDistanceMeters: 100,
+          targetTime: Duration(seconds: 88),
+          strokeRate: 72,
+        ),
+        actualSplits: const [
+          Duration(milliseconds: 22000),
+          Duration(milliseconds: 22400),
+        ],
+        strokeCounts: const [18, 19],
+        rpe: 7,
+        notes: ' Held rhythm ',
+      );
+
+      expect(saved.notes, 'Held rhythm');
+      expect(saved.actualSplits, hasLength(2));
+      expect(saved.strokeCounts, [18, 19]);
+      verify(() => dao.insertTempoSessionResult(any())).called(1);
+      verify(
+        () => queue.enqueue(
+          profileId: 'profile-1',
+          entityType: 'tempo_session_result',
+          entityId: saved.id,
+          operation: SyncOperation.create,
+          payload: any(named: 'payload'),
+        ),
+      ).called(1);
+    });
+  });
+}

--- a/test/features/tempo/tempo_trainer_provider_test.dart
+++ b/test/features/tempo/tempo_trainer_provider_test.dart
@@ -1,0 +1,74 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_mode.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_template.dart';
+import 'package:rep_swim/features/tempo/presentation/providers/tempo_cue_player.dart';
+import 'package:rep_swim/features/tempo/presentation/providers/tempo_trainer_provider.dart';
+
+class _FakeTempoCuePlayer implements TempoCuePlayer {
+  final cues = <bool>[];
+
+  @override
+  Future<void> playCue({
+    required TempoCueSettings settings,
+    required bool accent,
+  }) async {
+    cues.add(accent);
+  }
+}
+
+void main() {
+  group('TempoTrainerNotifier', () {
+    test('plays audible/vibration cue on start and accents configured beats',
+        () {
+      fakeAsync((async) {
+        final cuePlayer = _FakeTempoCuePlayer();
+        final notifier = TempoTrainerNotifier(cuePlayer);
+
+        notifier.configure(
+          mode: TempoMode.strokeRate,
+          poolLengthMeters: 25,
+          targetDistanceMeters: 100,
+          targetTime: const Duration(seconds: 90),
+          strokeRate: 60,
+          breathEveryStrokes: 3,
+          cueSettings: const TempoCueSettings(
+            audible: true,
+            vibration: true,
+            visualFlash: true,
+            accentEvery: 2,
+          ),
+          safetyWarningAcknowledged: false,
+        );
+
+        notifier.start();
+        async.elapse(const Duration(seconds: 2));
+
+        expect(cuePlayer.cues, [false, true, false]);
+        expect(notifier.state.beatCount, 3);
+        expect(notifier.state.flashActive, isTrue);
+
+        notifier.dispose();
+      });
+    });
+
+    test('breath pattern cue interval follows stroke rate and breath count',
+        () {
+      final notifier = TempoTrainerNotifier(_FakeTempoCuePlayer());
+
+      notifier.configure(
+        mode: TempoMode.breathPattern,
+        poolLengthMeters: 25,
+        targetDistanceMeters: 100,
+        targetTime: const Duration(seconds: 90),
+        strokeRate: 60,
+        breathEveryStrokes: 3,
+        cueSettings: const TempoCueSettings(),
+        safetyWarningAcknowledged: false,
+      );
+
+      expect(notifier.state.cueInterval, const Duration(seconds: 3));
+      notifier.dispose();
+    });
+  });
+}

--- a/test/features/tempo/tempo_trainer_screen_test.dart
+++ b/test/features/tempo/tempo_trainer_screen_test.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:rep_swim/core/sync/sync_mode.dart';
+import 'package:rep_swim/core/sync/sync_providers.dart';
+import 'package:rep_swim/database/daos/sync_queue_dao.dart';
 import 'package:rep_swim/database/daos/training_template_dao.dart';
+import 'package:rep_swim/features/profiles/presentation/providers/profile_providers.dart';
 import 'package:rep_swim/features/templates/presentation/providers/training_template_providers.dart';
 import 'package:rep_swim/features/tempo/domain/entities/tempo_mode.dart';
 import 'package:rep_swim/features/tempo/domain/entities/tempo_session_result.dart';
@@ -11,6 +16,8 @@ import 'package:rep_swim/features/tempo/presentation/providers/tempo_cue_player.
 import 'package:rep_swim/features/tempo/presentation/screens/tempo_trainer_screen.dart';
 
 class _MockTrainingTemplateDao extends Mock implements TrainingTemplateDao {}
+
+class _MockSyncQueueDao extends Mock implements SyncQueueDao {}
 
 class _FakeTempoCuePlayer implements TempoCuePlayer {
   int playCount = 0;
@@ -24,24 +31,61 @@ class _FakeTempoCuePlayer implements TempoCuePlayer {
   }
 }
 
-Future<_FakeTempoCuePlayer> _pumpTempoTrainer(WidgetTester tester) async {
+class _TempoScreenHarness {
+  const _TempoScreenHarness({
+    required this.dao,
+    required this.queue,
+    required this.cuePlayer,
+  });
+
+  final _MockTrainingTemplateDao dao;
+  final _MockSyncQueueDao queue;
+  final _FakeTempoCuePlayer cuePlayer;
+}
+
+Future<_TempoScreenHarness> _pumpTempoTrainer(WidgetTester tester) async {
   final dao = _MockTrainingTemplateDao();
+  final queue = _MockSyncQueueDao();
+  final cuePlayer = _FakeTempoCuePlayer();
   when(() => dao.getTempoTemplates(any())).thenAnswer((_) async => []);
   when(() => dao.getTempoSessionResults(any())).thenAnswer((_) async => []);
+  when(() => dao.insertTempoTemplate(any())).thenAnswer((_) async {});
   when(() => dao.insertTempoSessionResult(any())).thenAnswer((_) async {});
-  final cuePlayer = _FakeTempoCuePlayer();
+  when(
+    () => queue.enqueue(
+      profileId: any(named: 'profileId'),
+      entityType: any(named: 'entityType'),
+      entityId: any(named: 'entityId'),
+      operation: any(named: 'operation'),
+      payload: any(named: 'payload'),
+    ),
+  ).thenAnswer((_) async {});
 
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
         trainingTemplateDaoProvider.overrideWithValue(dao),
+        syncQueueDaoProvider.overrideWithValue(queue),
+        currentProfileIdProvider.overrideWithValue('profile-1'),
         tempoCuePlayerProvider.overrideWithValue(cuePlayer),
       ],
       child: const MaterialApp(home: TempoTrainerScreen()),
     ),
   );
   await tester.pump();
-  return cuePlayer;
+  return _TempoScreenHarness(
+    dao: dao,
+    queue: queue,
+    cuePlayer: cuePlayer,
+  );
+}
+
+Future<void> _scrollTo(WidgetTester tester, Finder finder) async {
+  await tester.scrollUntilVisible(
+    finder,
+    300,
+    scrollable: find.byType(Scrollable).first,
+  );
 }
 
 void main() {
@@ -75,11 +119,13 @@ void main() {
         strokeCounts: const [18],
       ),
     );
+    registerFallbackValue(SyncOperation.create);
+    registerFallbackValue(<String, Object?>{});
   });
 
   group('TempoTrainerScreen', () {
     testWidgets('shows tempo controls and cue outputs', (tester) async {
-      final cuePlayer = await _pumpTempoTrainer(tester);
+      final harness = await _pumpTempoTrainer(tester);
 
       expect(find.text('Tempo Trainer'), findsOneWidget);
       expect(find.text('Stroke Rate'), findsOneWidget);
@@ -92,7 +138,7 @@ void main() {
       await tester.tap(find.widgetWithText(FilledButton, 'Start'));
       await tester.pump();
 
-      expect(cuePlayer.playCount, 1);
+      expect(harness.cuePlayer.playCount, 1);
       expect(find.text('Stroke cue'), findsOneWidget);
 
       await tester.tap(find.widgetWithText(OutlinedButton, 'Reset'));
@@ -124,6 +170,98 @@ void main() {
         find.widgetWithText(FilledButton, 'Start'),
       );
       expect(enabledStart.onPressed, isNotNull);
+    });
+
+    testWidgets('validates configuration before applying', (tester) async {
+      await _pumpTempoTrainer(tester);
+
+      await tester.enterText(find.widgetWithText(TextField, 'Pool m'), '0');
+      await tester.tap(find.widgetWithText(FilledButton, 'Apply'));
+      await tester.pump();
+
+      expect(find.text('Enter valid tempo values.'), findsOneWidget);
+    });
+
+    testWidgets('saves the current setup as a tempo template', (tester) async {
+      final harness = await _pumpTempoTrainer(tester);
+
+      await _scrollTo(tester, find.widgetWithText(FilledButton, 'Save'));
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Template name'),
+        'Threshold tempo',
+      );
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.widgetWithText(FilledButton, 'Save'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      verify(() => harness.dao.insertTempoTemplate(any())).called(1);
+      expect(find.text('Saved Threshold tempo.'), findsOneWidget);
+    });
+
+    testWidgets('saves a tempo result with actual splits', (tester) async {
+      final harness = await _pumpTempoTrainer(tester);
+
+      await _scrollTo(
+        tester,
+        find.widgetWithText(TextField, 'Actual splits sec'),
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Actual splits sec'),
+        '22.0, 22.4',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Stroke counts'),
+        '18, 19',
+      );
+      await tester.enterText(find.widgetWithText(TextField, 'RPE 1-10'), '7');
+      await tester.enterText(find.widgetWithText(TextField, 'Notes'), 'Held');
+      await tester.tap(find.widgetWithText(FilledButton, 'Save Result'));
+      await tester.pumpAndSettle();
+
+      verify(() => harness.dao.insertTempoSessionResult(any())).called(1);
+      expect(find.text('Saved tempo result with 2 splits.'), findsOneWidget);
+    });
+
+    testWidgets('copies tempo result CSV from entered splits', (tester) async {
+      String? copiedText;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        if (call.method == 'Clipboard.setData') {
+          copiedText =
+              (call.arguments as Map<Object?, Object?>)['text'] as String?;
+        }
+        return null;
+      });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, null);
+      });
+      await _pumpTempoTrainer(tester);
+
+      await _scrollTo(
+        tester,
+        find.widgetWithText(TextField, 'Actual splits sec'),
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Actual splits sec'),
+        '22.0, 22.5',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Stroke counts'),
+        '18, 19',
+      );
+      await tester.tap(find.widgetWithText(OutlinedButton, 'CSV'));
+      await tester.pumpAndSettle();
+
+      expect(copiedText, contains('session_id,mode,split_index'));
+      expect(copiedText, contains('preview,strokeRate,1,22500,22000,-500,18'));
+      expect(find.text('Copied tempo CSV.'), findsOneWidget);
     });
   });
 }

--- a/test/features/tempo/tempo_trainer_screen_test.dart
+++ b/test/features/tempo/tempo_trainer_screen_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:rep_swim/database/daos/training_template_dao.dart';
+import 'package:rep_swim/features/templates/presentation/providers/training_template_providers.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_mode.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_session_result.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_template.dart';
+import 'package:rep_swim/features/tempo/presentation/providers/tempo_cue_player.dart';
+import 'package:rep_swim/features/tempo/presentation/screens/tempo_trainer_screen.dart';
+
+class _MockTrainingTemplateDao extends Mock implements TrainingTemplateDao {}
+
+class _FakeTempoCuePlayer implements TempoCuePlayer {
+  int playCount = 0;
+
+  @override
+  Future<void> playCue({
+    required TempoCueSettings settings,
+    required bool accent,
+  }) async {
+    playCount++;
+  }
+}
+
+Future<_FakeTempoCuePlayer> _pumpTempoTrainer(WidgetTester tester) async {
+  final dao = _MockTrainingTemplateDao();
+  when(() => dao.getTempoTemplates(any())).thenAnswer((_) async => []);
+  when(() => dao.getTempoSessionResults(any())).thenAnswer((_) async => []);
+  when(() => dao.insertTempoSessionResult(any())).thenAnswer((_) async {});
+  final cuePlayer = _FakeTempoCuePlayer();
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        trainingTemplateDaoProvider.overrideWithValue(dao),
+        tempoCuePlayerProvider.overrideWithValue(cuePlayer),
+      ],
+      child: const MaterialApp(home: TempoTrainerScreen()),
+    ),
+  );
+  await tester.pump();
+  return cuePlayer;
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      TempoTemplate(
+        id: 'template-1',
+        name: 'Race pace',
+        mode: TempoMode.strokeRate,
+        poolLengthMeters: 25,
+        targetDistanceMeters: 100,
+        targetTime: const Duration(seconds: 90),
+        strokeRate: 60,
+        breathEveryStrokes: 3,
+        cueSettings: const TempoCueSettings(),
+        safetyWarningAcknowledged: false,
+        createdAt: DateTime.utc(2024),
+        updatedAt: DateTime.utc(2024),
+      ),
+    );
+    registerFallbackValue(
+      TempoSessionResult(
+        id: 'result-1',
+        mode: TempoMode.strokeRate,
+        startedAt: DateTime.utc(2024),
+        targetDistanceMeters: 100,
+        poolLengthMeters: 25,
+        targetTime: const Duration(seconds: 90),
+        targetStrokeRate: 60,
+        actualSplits: const [Duration(seconds: 22)],
+        strokeCounts: const [18],
+      ),
+    );
+  });
+
+  group('TempoTrainerScreen', () {
+    testWidgets('shows tempo controls and cue outputs', (tester) async {
+      final cuePlayer = await _pumpTempoTrainer(tester);
+
+      expect(find.text('Tempo Trainer'), findsOneWidget);
+      expect(find.text('Stroke Rate'), findsOneWidget);
+      expect(find.text('Sound'), findsOneWidget);
+      expect(find.text('Vibration'), findsOneWidget);
+      expect(find.text('Visual flash'), findsOneWidget);
+
+      await tester.ensureVisible(find.widgetWithText(FilledButton, 'Start'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, 'Start'));
+      await tester.pump();
+
+      expect(cuePlayer.playCount, 1);
+      expect(find.text('Stroke cue'), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(OutlinedButton, 'Reset'));
+      await tester.pump(const Duration(milliseconds: 200));
+    });
+
+    testWidgets('requires acknowledgement for high breath rhythm cues',
+        (tester) async {
+      await _pumpTempoTrainer(tester);
+
+      await tester.tap(find.text('Breath Pattern'));
+      await tester.pump();
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Breathe every'),
+        '5',
+      );
+      await tester.tap(find.widgetWithText(FilledButton, 'Apply'));
+      await tester.pump();
+
+      expect(find.text('Breath safety acknowledged'), findsOneWidget);
+      final startButton = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Start'),
+      );
+      expect(startButton.onPressed, isNull);
+
+      await tester.tap(find.byType(CheckboxListTile));
+      await tester.pump();
+      final enabledStart = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Start'),
+      );
+      expect(enabledStart.onPressed, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add a new Tempo Trainer screen at /tempo for stroke-rate, lap-pace, and breath-pattern cue training.
- Add configurable sound, vibration, visual flash, voice announcement, and accent cue behavior.
- Add offline SQLite persistence for tempo templates and session results, sync payloads, CSV export, and documentation.
- Harden MVP coverage with unit, provider, widget, DAO integration, sync payload, and migration tests.

## Follow-up issues
- #15 Tempo session history/detail views
- #16 Low-drift audio scheduling
- #17 CSS pace preset builder
- #18 USRPT race-pace preset with fail counter
- #19 Stroke-rate ramp test preset

## Tests
- dart format lib test
- flutter analyze
- flutter test

Closes #13