### PR TITLE
feat: add tempo result history

### DIFF
--- a/docs/tempo-trainer.md
+++ b/docs/tempo-trainer.md
@@ -142,10 +142,15 @@ At least one actual split is required to save a result. RPE must be blank or in
 the range `1..10`.
 
 Saved results are stored in SQLite in `tempo_session_results` and are scoped to
-the current swimmer profile. Result creates are queued for sync.
+the current swimmer profile. Result creates and deletes are queued for sync.
 
-The MVP stores results and shows a count of saved tempo sessions. It does not
-yet include a dedicated history or detail screen for viewing saved results.
+The `History` action in the Tempo Trainer app bar opens the saved result list.
+Tempo History shows saved results newest first, and each row opens a detail view
+with target pace, split errors, stroke counts, RPE, and notes. Saved results can
+be deleted from the detail view after confirmation.
+
+History and detail views do not play live tempo cues, so they do not introduce
+additional audio, vibration, or visual flash behavior.
 
 ## CSV Export
 
@@ -181,7 +186,7 @@ Current coverage includes:
 - Provider tests for cue scheduling, template save/delete, result save, and sync
   queue behavior.
 - Widget tests for controls, safety acknowledgement, validation, template save,
-  result save, and CSV copy.
+  result save, history, detail, delete, and CSV copy.
 - DAO integration tests for offline persistence and profile isolation.
 - Migration tests for upgrading older database versions to the tempo schema.
 
@@ -190,7 +195,6 @@ Current coverage includes:
 The MVP intentionally does not include:
 
 - Low-drift audio scheduling.
-- Saved session history/detail screens.
 - CSS pace preset generation.
 - Stroke-rate ramp tests.
 - USRPT race-pace presets and fail counters.
@@ -199,7 +203,6 @@ The MVP intentionally does not include:
 
 Follow-up issues:
 
-- #15 Tempo session history/detail views.
 - #16 Low-drift audio scheduling.
 - #17 CSS pace preset builder.
 - #18 USRPT race-pace preset with fail counter.

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -11,6 +11,7 @@ import 'features/swim/presentation/screens/swim_session_screen.dart';
 import 'features/stopwatch/presentation/screens/stopwatch_screen.dart';
 import 'features/stopwatch/presentation/screens/interval_timer_screen.dart';
 import 'features/stopwatch/presentation/providers/stopwatch_display_style_provider.dart';
+import 'features/tempo/presentation/screens/tempo_results_screen.dart';
 import 'features/tempo/presentation/screens/tempo_trainer_screen.dart';
 import 'features/pb/presentation/screens/pb_screen.dart';
 import 'features/profiles/presentation/screens/profiles_screen.dart';
@@ -91,6 +92,16 @@ final _router = GoRouter(
     GoRoute(
       path: '/tempo',
       builder: (context, state) => const TempoTrainerScreen(),
+    ),
+    GoRoute(
+      path: '/tempo/results',
+      builder: (context, state) => const TempoResultsScreen(),
+    ),
+    GoRoute(
+      path: '/tempo/results/:id',
+      builder: (context, state) => TempoResultDetailScreen(
+        resultId: state.pathParameters['id']!,
+      ),
     ),
     GoRoute(
       path: '/settings/sync',

--- a/lib/database/daos/training_template_dao.dart
+++ b/lib/database/daos/training_template_dao.dart
@@ -212,6 +212,15 @@ class TrainingTemplateDao {
     return rows.map(_tempoSessionResultFromRow).toList();
   }
 
+  Future<void> deleteTempoSessionResult(String id, String profileId) async {
+    final db = await _db.database;
+    await db.delete(
+      'tempo_session_results',
+      where: 'id = ? AND profile_id = ?',
+      whereArgs: [id, profileId],
+    );
+  }
+
   Future<List<DrylandRoutineExerciseTemplate>> getDrylandRoutineExercises(
     String templateId,
     String profileId,

--- a/lib/features/tempo/presentation/providers/tempo_template_providers.dart
+++ b/lib/features/tempo/presentation/providers/tempo_template_providers.dart
@@ -171,6 +171,17 @@ class TempoSessionResultsNotifier
     return result;
   }
 
+  Future<void> deleteResult(String id) async {
+    await _dao.deleteTempoSessionResult(id, _profileId);
+    await _queueChange(
+      entityType: 'tempo_session_result',
+      entityId: id,
+      operation: SyncOperation.delete,
+      payload: deletedEntityPayload(id: id, profileId: _profileId),
+    );
+    await load();
+  }
+
   Future<void> _queueChange({
     required String entityType,
     required String entityId,

--- a/lib/features/tempo/presentation/screens/tempo_results_screen.dart
+++ b/lib/features/tempo/presentation/screens/tempo_results_screen.dart
@@ -1,0 +1,363 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../core/utils/duration_utils.dart';
+import '../../domain/entities/tempo_mode.dart';
+import '../../domain/entities/tempo_session_result.dart';
+import '../../domain/services/tempo_calculator.dart';
+import '../providers/tempo_template_providers.dart';
+
+class TempoResultsScreen extends ConsumerWidget {
+  const TempoResultsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final resultsAsync = ref.watch(tempoSessionResultsProvider);
+
+    return resultsAsync.when(
+      data: (results) => Scaffold(
+        appBar: AppBar(title: const Text('Tempo History')),
+        body: results.isEmpty
+            ? const Center(child: Text('No tempo sessions yet'))
+            : ListView.separated(
+                padding: const EdgeInsets.all(16),
+                itemCount: results.length,
+                separatorBuilder: (_, __) => const SizedBox(height: 8),
+                itemBuilder: (context, index) {
+                  final result = results[index];
+                  return _TempoResultTile(result: result);
+                },
+              ),
+      ),
+      loading: () => Scaffold(
+        appBar: AppBar(title: const Text('Tempo History')),
+        body: const Center(child: CircularProgressIndicator.adaptive()),
+      ),
+      error: (error, _) => Scaffold(
+        appBar: AppBar(title: const Text('Tempo History')),
+        body: Center(child: Text('Error: $error')),
+      ),
+    );
+  }
+}
+
+class TempoResultDetailScreen extends ConsumerWidget {
+  const TempoResultDetailScreen({
+    super.key,
+    required this.resultId,
+  });
+
+  final String resultId;
+
+  Future<void> _deleteResult(
+    BuildContext context,
+    WidgetRef ref,
+    TempoSessionResult result,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Delete tempo result?'),
+        content: const Text('This removes the saved tempo session result.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+    await ref
+        .read(tempoSessionResultsProvider.notifier)
+        .deleteResult(result.id);
+    if (!context.mounted) return;
+    final messenger = ScaffoldMessenger.of(context);
+    context.pop();
+    messenger.showSnackBar(
+      const SnackBar(content: Text('Tempo result deleted.')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final resultsAsync = ref.watch(tempoSessionResultsProvider);
+
+    return resultsAsync.when(
+      data: (results) {
+        final matches = results.where((result) => result.id == resultId);
+        if (matches.isEmpty) {
+          return Scaffold(
+            appBar: AppBar(title: const Text('Tempo Result')),
+            body: const Center(child: Text('Tempo result not found')),
+          );
+        }
+
+        final result = matches.first;
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('Tempo Result'),
+            actions: [
+              IconButton(
+                icon: const Icon(Icons.delete_outline),
+                tooltip: 'Delete tempo result',
+                onPressed: () => _deleteResult(context, ref, result),
+              ),
+            ],
+          ),
+          body: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              _TempoResultSummary(result: result),
+              const SizedBox(height: 16),
+              if (result.notes != null && result.notes!.isNotEmpty) ...[
+                _NotesCard(notes: result.notes!),
+                const SizedBox(height: 16),
+              ],
+              Text(
+                'Splits',
+                style: Theme.of(context)
+                    .textTheme
+                    .titleMedium
+                    ?.copyWith(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 8),
+              ..._splitRows(result),
+            ],
+          ),
+        );
+      },
+      loading: () => Scaffold(
+        appBar: AppBar(title: const Text('Tempo Result')),
+        body: const Center(child: CircularProgressIndicator.adaptive()),
+      ),
+      error: (error, _) => Scaffold(
+        appBar: AppBar(title: const Text('Tempo Result')),
+        body: Center(child: Text('Error: $error')),
+      ),
+    );
+  }
+
+  List<Widget> _splitRows(TempoSessionResult result) {
+    final targetSplit = const TempoCalculator().splitForDistance(
+      targetTime: result.targetTime,
+      targetDistanceMeters: result.targetDistanceMeters,
+      splitDistanceMeters: result.poolLengthMeters,
+    );
+    final splitResults = const TempoCalculator().compareSplits(
+      actualSplits: result.actualSplits,
+      targetSplit: targetSplit,
+      strokeCounts: result.strokeCounts,
+    );
+    return [
+      for (final split in splitResults) _SplitTile(split: split),
+    ];
+  }
+}
+
+class _TempoResultTile extends StatelessWidget {
+  const _TempoResultTile({required this.result});
+
+  final TempoSessionResult result;
+
+  @override
+  Widget build(BuildContext context) {
+    final date = DateFormat('d MMM yyyy, h:mm a').format(result.startedAt);
+    final pace = DurationUtils.formatPace(
+      result.targetTime,
+      result.targetDistanceMeters,
+    );
+    return Card(
+      child: ListTile(
+        onTap: () => context.push('/tempo/results/${result.id}'),
+        leading: CircleAvatar(
+          child: Icon(_modeIcon(result)),
+        ),
+        title: Text('${result.mode.label} - ${result.targetDistanceMeters}m'),
+        subtitle: Text(
+          '$date - ${result.actualSplits.length} splits - $pace'
+          '${result.rpe == null ? '' : ' - RPE ${result.rpe}'}',
+        ),
+        trailing: const Icon(Icons.chevron_right),
+      ),
+    );
+  }
+}
+
+class _TempoResultSummary extends StatelessWidget {
+  const _TempoResultSummary({required this.result});
+
+  final TempoSessionResult result;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final date = DateFormat('EEEE, d MMM yyyy').format(result.startedAt);
+    final time = DateFormat('h:mm a').format(result.startedAt);
+    final pace = DurationUtils.formatPace(
+      result.targetTime,
+      result.targetDistanceMeters,
+    );
+
+    return Card(
+      color: colorScheme.primaryContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              result.mode.label,
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                    color: colorScheme.onPrimaryContainer,
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '$date at $time',
+              style: TextStyle(
+                color: colorScheme.onPrimaryContainer.withValues(alpha: 0.75),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                _SummaryChip(
+                  icon: Icons.straighten,
+                  label: '${result.targetDistanceMeters}m',
+                ),
+                _SummaryChip(
+                  icon: Icons.pool_outlined,
+                  label: '${result.poolLengthMeters}m pool',
+                ),
+                _SummaryChip(
+                  icon: Icons.timer_outlined,
+                  label: DurationUtils.formatDuration(result.targetTime),
+                ),
+                _SummaryChip(
+                  icon: Icons.speed,
+                  label: pace,
+                ),
+                _SummaryChip(
+                  icon: Icons.graphic_eq,
+                  label: '${result.targetStrokeRate.toStringAsFixed(1)} spm',
+                ),
+                if (result.rpe != null)
+                  _SummaryChip(
+                    icon: Icons.monitor_heart_outlined,
+                    label: 'RPE ${result.rpe}',
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SplitTile extends StatelessWidget {
+  const _SplitTile({required this.split});
+
+  final TempoSplitResult split;
+
+  @override
+  Widget build(BuildContext context) {
+    final onPace = split.isOnPace;
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: ListTile(
+        leading: CircleAvatar(child: Text('${split.index}')),
+        title: Text(
+          DurationUtils.formatDurationWithCentiseconds(split.actualSplit),
+        ),
+        subtitle: Text(
+          'Target ${DurationUtils.formatDurationWithCentiseconds(split.targetSplit)}'
+          ' - Error ${_formatSignedDuration(split.error)}'
+          ' - Strokes ${split.strokeCount?.toString() ?? '-'}',
+        ),
+        trailing: Chip(
+          label: Text(onPace ? 'On pace' : 'Off pace'),
+          avatar: Icon(
+            onPace ? Icons.check_circle_outline : Icons.error_outline,
+            size: 16,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NotesCard extends StatelessWidget {
+  const _NotesCard({required this.notes});
+
+  final String notes;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Notes',
+              style: Theme.of(context)
+                  .textTheme
+                  .titleSmall
+                  ?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Text(notes),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SummaryChip extends StatelessWidget {
+  const _SummaryChip({
+    required this.icon,
+    required this.label,
+  });
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Chip(
+      avatar: Icon(icon, size: 16),
+      label: Text(label),
+      backgroundColor: colorScheme.surface,
+      side: BorderSide.none,
+    );
+  }
+}
+
+IconData _modeIcon(TempoSessionResult result) {
+  return switch (result.mode) {
+    TempoMode.strokeRate => Icons.speed,
+    TempoMode.lapPace => Icons.flag_outlined,
+    TempoMode.breathPattern => Icons.air,
+  };
+}
+
+String _formatSignedDuration(Duration duration) {
+  final sign = duration.isNegative ? '-' : '+';
+  final absolute = duration.isNegative ? -duration : duration;
+  return '$sign${DurationUtils.formatDurationWithCentiseconds(absolute)}';
+}

--- a/lib/features/tempo/presentation/screens/tempo_trainer_screen.dart
+++ b/lib/features/tempo/presentation/screens/tempo_trainer_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../../core/utils/duration_utils.dart';
 import '../../domain/entities/tempo_mode.dart';
@@ -260,7 +261,16 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
     });
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Tempo Trainer')),
+      appBar: AppBar(
+        title: const Text('Tempo Trainer'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.history),
+            tooltip: 'Tempo history',
+            onPressed: () => context.push('/tempo/results'),
+          ),
+        ],
+      ),
       body: SafeArea(
         child: ListView(
           padding: const EdgeInsets.all(16),

--- a/test/database/dao_integration_test.dart
+++ b/test/database/dao_integration_test.dart
@@ -262,6 +262,10 @@ void main() {
       expect(results.single.strokeCounts, [18, 19]);
       expect(results.single.notes, 'Held rhythm');
       expect(await dao.getTempoSessionResults('profile-2'), hasLength(1));
+
+      await dao.deleteTempoSessionResult('tempo-result-1', 'profile-1');
+      expect(await dao.getTempoSessionResults('profile-1'), isEmpty);
+      expect(await dao.getTempoSessionResults('profile-2'), hasLength(1));
     });
 
     test('sync queue preserves insertion order and increments retry count',

--- a/test/features/tempo/tempo_results_screen_test.dart
+++ b/test/features/tempo/tempo_results_screen_test.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:rep_swim/core/sync/sync_mode.dart';
+import 'package:rep_swim/core/sync/sync_providers.dart';
+import 'package:rep_swim/database/daos/sync_queue_dao.dart';
+import 'package:rep_swim/database/daos/training_template_dao.dart';
+import 'package:rep_swim/features/profiles/presentation/providers/profile_providers.dart';
+import 'package:rep_swim/features/templates/presentation/providers/training_template_providers.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_mode.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_session_result.dart';
+import 'package:rep_swim/features/tempo/domain/entities/tempo_template.dart';
+import 'package:rep_swim/features/tempo/presentation/screens/tempo_results_screen.dart';
+
+class _MockTrainingTemplateDao extends Mock implements TrainingTemplateDao {}
+
+class _MockSyncQueueDao extends Mock implements SyncQueueDao {}
+
+TempoSessionResult _tempoResult() {
+  return TempoSessionResult(
+    id: 'result-1',
+    profileId: 'profile-1',
+    mode: TempoMode.lapPace,
+    startedAt: DateTime(2024, 5, 1, 7, 30),
+    completedAt: DateTime(2024, 5, 1, 7, 35),
+    targetDistanceMeters: 100,
+    poolLengthMeters: 25,
+    targetTime: const Duration(seconds: 90),
+    targetStrokeRate: 72,
+    actualSplits: const [
+      Duration(seconds: 22),
+      Duration(milliseconds: 23700),
+    ],
+    strokeCounts: const [18, 20],
+    rpe: 7,
+    notes: 'Held rhythm',
+  );
+}
+
+Future<_MockTrainingTemplateDao> _pumpResultsApp(
+  WidgetTester tester, {
+  required List<TempoSessionResult> results,
+  String initialLocation = '/tempo/results',
+}) async {
+  final dao = _MockTrainingTemplateDao();
+  final queue = _MockSyncQueueDao();
+  when(() => dao.getTempoSessionResults(any()))
+      .thenAnswer((_) async => results);
+  when(() => dao.deleteTempoSessionResult(any(), any()))
+      .thenAnswer((_) async {});
+  when(
+    () => queue.enqueue(
+      profileId: any(named: 'profileId'),
+      entityType: any(named: 'entityType'),
+      entityId: any(named: 'entityId'),
+      operation: any(named: 'operation'),
+      payload: any(named: 'payload'),
+    ),
+  ).thenAnswer((_) async {});
+
+  final router = GoRouter(
+    initialLocation: initialLocation,
+    routes: [
+      GoRoute(
+        path: '/tempo/results',
+        builder: (context, state) => const TempoResultsScreen(),
+        routes: [
+          GoRoute(
+            path: ':id',
+            builder: (context, state) => TempoResultDetailScreen(
+              resultId: state.pathParameters['id']!,
+            ),
+          ),
+        ],
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        trainingTemplateDaoProvider.overrideWithValue(dao),
+        syncQueueDaoProvider.overrideWithValue(queue),
+        currentProfileIdProvider.overrideWithValue('profile-1'),
+      ],
+      child: MaterialApp.router(routerConfig: router),
+    ),
+  );
+  await tester.pump();
+  return dao;
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      TempoSessionResult(
+        id: 'fallback-result',
+        mode: TempoMode.strokeRate,
+        startedAt: DateTime(2024),
+        targetDistanceMeters: 100,
+        poolLengthMeters: 25,
+        targetTime: const Duration(seconds: 90),
+        targetStrokeRate: 60,
+        actualSplits: const [Duration(seconds: 22)],
+        strokeCounts: const [18],
+      ),
+    );
+    registerFallbackValue(
+      TempoTemplate(
+        id: 'fallback-template',
+        name: 'Template',
+        mode: TempoMode.strokeRate,
+        poolLengthMeters: 25,
+        targetDistanceMeters: 100,
+        targetTime: const Duration(seconds: 90),
+        strokeRate: 60,
+        breathEveryStrokes: 3,
+        cueSettings: const TempoCueSettings(),
+        safetyWarningAcknowledged: false,
+        createdAt: DateTime(2024),
+        updatedAt: DateTime(2024),
+      ),
+    );
+    registerFallbackValue(SyncOperation.create);
+    registerFallbackValue(<String, Object?>{});
+  });
+
+  group('TempoResultsScreen', () {
+    testWidgets('shows empty state when no tempo results exist',
+        (tester) async {
+      await _pumpResultsApp(tester, results: const []);
+
+      expect(find.text('Tempo History'), findsOneWidget);
+      expect(find.text('No tempo sessions yet'), findsOneWidget);
+    });
+
+    testWidgets('lists saved tempo results and opens detail', (tester) async {
+      await _pumpResultsApp(tester, results: [_tempoResult()]);
+
+      expect(find.text('Lap Pace - 100m'), findsOneWidget);
+      expect(find.textContaining('2 splits'), findsOneWidget);
+      expect(find.textContaining('1:30/100m'), findsOneWidget);
+      expect(find.textContaining('RPE 7'), findsOneWidget);
+
+      await tester.tap(find.text('Lap Pace - 100m'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text('Tempo Result'), findsOneWidget);
+      expect(find.text('Lap Pace'), findsWidgets);
+      expect(find.text('100m'), findsOneWidget);
+      expect(find.text('25m pool'), findsOneWidget);
+      expect(find.text('72.0 spm'), findsOneWidget);
+      expect(find.text('Held rhythm'), findsOneWidget);
+      expect(find.textContaining('Error -00:00.50'), findsOneWidget);
+      expect(find.textContaining('Strokes 18'), findsOneWidget);
+      expect(find.text('On pace'), findsOneWidget);
+      expect(find.text('Off pace'), findsOneWidget);
+    });
+
+    testWidgets('shows not found state for missing result', (tester) async {
+      await _pumpResultsApp(
+        tester,
+        results: [_tempoResult()],
+        initialLocation: '/tempo/results/missing',
+      );
+
+      expect(find.text('Tempo result not found'), findsOneWidget);
+    });
+
+    testWidgets('deletes a saved tempo result after confirmation',
+        (tester) async {
+      final dao = await _pumpResultsApp(tester, results: [_tempoResult()]);
+
+      await tester.tap(find.text('Lap Pace - 100m'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.byTooltip('Delete tempo result'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text('Delete tempo result?'), findsOneWidget);
+      await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      verify(() => dao.deleteTempoSessionResult('result-1', 'profile-1'))
+          .called(1);
+      expect(find.text('Tempo result deleted.'), findsOneWidget);
+      expect(find.text('Tempo History'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/tempo/tempo_template_providers_test.dart
+++ b/test/features/tempo/tempo_template_providers_test.dart
@@ -202,5 +202,45 @@ void main() {
         ),
       ).called(1);
     });
+
+    test('deletes session result by profile and queues deletion', () async {
+      final dao = _MockTrainingTemplateDao();
+      final queue = _MockSyncQueueDao();
+      when(() => dao.getTempoSessionResults(any())).thenAnswer((_) async => []);
+      when(() => dao.deleteTempoSessionResult(any(), any()))
+          .thenAnswer((_) async {});
+      when(
+        () => queue.enqueue(
+          profileId: any(named: 'profileId'),
+          entityType: any(named: 'entityType'),
+          entityId: any(named: 'entityId'),
+          operation: any(named: 'operation'),
+          payload: any(named: 'payload'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final notifier = TempoSessionResultsNotifier(
+        dao,
+        'profile-1',
+        syncQueueDao: queue,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      await notifier.deleteResult('tempo-result-1');
+
+      verify(() => dao.deleteTempoSessionResult('tempo-result-1', 'profile-1'))
+          .called(1);
+      verify(
+        () => queue.enqueue(
+          profileId: 'profile-1',
+          entityType: 'tempo_session_result',
+          entityId: 'tempo-result-1',
+          operation: SyncOperation.delete,
+          payload: any(named: 'payload'),
+        ),
+      ).called(1);
+      verify(() => dao.getTempoSessionResults('profile-1'))
+          .called(greaterThanOrEqualTo(2));
+    });
   });
 }

--- a/test/features/tempo/tempo_trainer_screen_test.dart
+++ b/test/features/tempo/tempo_trainer_screen_test.dart
@@ -132,6 +132,7 @@ void main() {
       expect(find.text('Sound'), findsOneWidget);
       expect(find.text('Vibration'), findsOneWidget);
       expect(find.text('Visual flash'), findsOneWidget);
+      expect(find.byTooltip('Tempo history'), findsOneWidget);
 
       await tester.ensureVisible(find.widgetWithText(FilledButton, 'Start'));
       await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- add Tempo History and Tempo Result detail routes for saved tempo sessions
- support deleting tempo session results with sync queue tombstones
- document the saved history behavior and audio/vibration scope

## Tests
- dart format lib test
- flutter analyze
- flutter test

Closes #15