### PR TITLE
feat: add low-drift tempo cue scheduler

### DIFF
--- a/docs/tempo-trainer.md
+++ b/docs/tempo-trainer.md
@@ -80,8 +80,16 @@ Cue output settings are configured with chips:
 The cue player is implemented behind `TempoCuePlayer` so tests can inject a fake
 cue player without calling platform channels.
 
-Current timing uses Flutter timers. This is adequate for the MVP but is not a
-specialized low-drift audio scheduler.
+Cue timing is implemented behind `TempoCueScheduler`. The scheduler uses a
+stopwatch-backed, one-shot timer loop that schedules each cue against its
+absolute target elapsed time. If a cue fires late, the next delay is shortened to
+return to the configured tempo instead of carrying the delay forward like
+`Timer.periodic`.
+
+Sound, vibration, visual flash, and spoken cues remain controlled by
+`TempoCueSettings` and `TempoCuePlayer`. The current implementation keeps using
+Flutter platform sound, haptic, and semantics APIs for cue output rather than
+adding a native audio engine package.
 
 ## Safety Behavior
 
@@ -177,7 +185,7 @@ alongside the existing interval and dryland template storage.
 Current coverage includes:
 
 - Unit tests for tempo conversions, split comparison, breath safety thresholds,
-  and CSV export.
+  CSV export, and low-drift cue scheduling.
 - Provider tests for cue scheduling, template save/delete, result save, and sync
   queue behavior.
 - Widget tests for controls, safety acknowledgement, validation, template save,
@@ -189,7 +197,6 @@ Current coverage includes:
 
 The MVP intentionally does not include:
 
-- Low-drift audio scheduling.
 - Saved session history/detail screens.
 - CSS pace preset generation.
 - Stroke-rate ramp tests.
@@ -200,7 +207,6 @@ The MVP intentionally does not include:
 Follow-up issues:
 
 - #15 Tempo session history/detail views.
-- #16 Low-drift audio scheduling.
 - #17 CSS pace preset builder.
 - #18 USRPT race-pace preset with fail counter.
 - #19 Stroke-rate ramp test preset.

--- a/lib/features/tempo/presentation/providers/tempo_cue_scheduler.dart
+++ b/lib/features/tempo/presentation/providers/tempo_cue_scheduler.dart
@@ -1,0 +1,101 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+typedef TempoTimerFactory = Timer Function(
+  Duration duration,
+  void Function() callback,
+);
+
+abstract class TempoClock {
+  Duration get elapsed;
+  void start();
+  void stop();
+  void reset();
+}
+
+class StopwatchTempoClock implements TempoClock {
+  final Stopwatch _stopwatch = Stopwatch();
+
+  @override
+  Duration get elapsed => _stopwatch.elapsed;
+
+  @override
+  void start() => _stopwatch.start();
+
+  @override
+  void stop() => _stopwatch.stop();
+
+  @override
+  void reset() => _stopwatch.reset();
+}
+
+class TempoCueScheduler {
+  TempoCueScheduler({
+    TempoTimerFactory? timerFactory,
+    TempoClock Function()? clockFactory,
+  })  : _timerFactory = timerFactory ?? Timer.new,
+        _clockFactory = clockFactory ?? StopwatchTempoClock.new;
+
+  final TempoTimerFactory _timerFactory;
+  final TempoClock Function() _clockFactory;
+
+  TempoClock? _clock;
+  Timer? _timer;
+  Duration _interval = Duration.zero;
+  int _nextCueIndex = 1;
+  void Function()? _onCue;
+
+  bool get isRunning => _clock != null;
+
+  void start({
+    required Duration interval,
+    required void Function() onCue,
+  }) {
+    if (interval <= Duration.zero) {
+      throw ArgumentError.value(interval, 'interval', 'must be positive');
+    }
+
+    stop();
+    _interval = interval;
+    _onCue = onCue;
+    _nextCueIndex = 1;
+    _clock = _clockFactory()
+      ..reset()
+      ..start();
+    _scheduleNextCue();
+  }
+
+  void stop() {
+    _timer?.cancel();
+    _timer = null;
+    _clock?.stop();
+    _clock = null;
+    _onCue = null;
+    _nextCueIndex = 1;
+  }
+
+  void _scheduleNextCue() {
+    final clock = _clock;
+    if (clock == null) return;
+
+    final targetElapsed = _interval * _nextCueIndex;
+    final delay = targetElapsed - clock.elapsed;
+    _timer = _timerFactory(
+      delay.isNegative ? Duration.zero : delay,
+      _handleCue,
+    );
+  }
+
+  void _handleCue() {
+    if (_clock == null) return;
+
+    _onCue?.call();
+    _nextCueIndex += 1;
+    _scheduleNextCue();
+  }
+}
+
+final tempoCueSchedulerProvider = Provider<TempoCueScheduler>(
+  (ref) => TempoCueScheduler(),
+);

--- a/lib/features/tempo/presentation/providers/tempo_trainer_provider.dart
+++ b/lib/features/tempo/presentation/providers/tempo_trainer_provider.dart
@@ -6,6 +6,7 @@ import '../../domain/entities/tempo_mode.dart';
 import '../../domain/entities/tempo_template.dart';
 import '../../domain/services/tempo_calculator.dart';
 import 'tempo_cue_player.dart';
+import 'tempo_cue_scheduler.dart';
 
 class TempoTrainerState {
   const TempoTrainerState({
@@ -127,10 +128,14 @@ class TempoTrainerState {
 }
 
 class TempoTrainerNotifier extends StateNotifier<TempoTrainerState> {
-  TempoTrainerNotifier(this._cuePlayer) : super(const TempoTrainerState());
+  TempoTrainerNotifier(
+    this._cuePlayer, {
+    TempoCueScheduler? cueScheduler,
+  })  : _cueScheduler = cueScheduler ?? TempoCueScheduler(),
+        super(const TempoTrainerState());
 
   final TempoCuePlayer _cuePlayer;
-  Timer? _timer;
+  final TempoCueScheduler _cueScheduler;
 
   void configure({
     required TempoMode mode,
@@ -173,19 +178,20 @@ class TempoTrainerNotifier extends StateNotifier<TempoTrainerState> {
     if (state.isRunning) return;
     state = state.copyWith(isRunning: true, lastCueLabel: 'Running');
     _playCue();
-    _timer = Timer.periodic(state.cueInterval, (_) => _playCue());
+    _cueScheduler.start(
+      interval: state.cueInterval,
+      onCue: _playCue,
+    );
   }
 
   void pause() {
     if (!state.isRunning) return;
-    _timer?.cancel();
-    _timer = null;
+    _cueScheduler.stop();
     state = state.copyWith(isRunning: false, lastCueLabel: 'Paused');
   }
 
   void stop() {
-    _timer?.cancel();
-    _timer = null;
+    _cueScheduler.stop();
     state = state.copyWith(
       isRunning: false,
       beatCount: 0,
@@ -200,7 +206,7 @@ class TempoTrainerNotifier extends StateNotifier<TempoTrainerState> {
     state = state.copyWith(flashActive: false);
   }
 
-  Future<void> _playCue() async {
+  void _playCue() {
     final nextBeat = state.beatCount + 1;
     final accentEvery = state.cueSettings.accentEvery;
     final accent = accentEvery > 0 && nextBeat % accentEvery == 0;
@@ -210,7 +216,7 @@ class TempoTrainerNotifier extends StateNotifier<TempoTrainerState> {
       flashActive: state.cueSettings.visualFlash,
       lastCueLabel: accent ? 'Accent cue' : _cueLabelForMode(state.mode),
     );
-    await _cuePlayer.playCue(settings: state.cueSettings, accent: accent);
+    unawaited(_cuePlayer.playCue(settings: state.cueSettings, accent: accent));
   }
 
   String _cueLabelForMode(TempoMode mode) {
@@ -223,12 +229,15 @@ class TempoTrainerNotifier extends StateNotifier<TempoTrainerState> {
 
   @override
   void dispose() {
-    _timer?.cancel();
+    _cueScheduler.stop();
     super.dispose();
   }
 }
 
 final tempoTrainerProvider =
     StateNotifierProvider<TempoTrainerNotifier, TempoTrainerState>(
-  (ref) => TempoTrainerNotifier(ref.read(tempoCuePlayerProvider)),
+  (ref) => TempoTrainerNotifier(
+    ref.read(tempoCuePlayerProvider),
+    cueScheduler: ref.read(tempoCueSchedulerProvider),
+  ),
 );

--- a/test/features/tempo/tempo_cue_scheduler_test.dart
+++ b/test/features/tempo/tempo_cue_scheduler_test.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/tempo/presentation/providers/tempo_cue_scheduler.dart';
+
+class _FakeTempoClock implements TempoClock {
+  @override
+  Duration elapsed = Duration.zero;
+  bool started = false;
+
+  @override
+  void start() => started = true;
+
+  @override
+  void stop() => started = false;
+
+  @override
+  void reset() => elapsed = Duration.zero;
+}
+
+class _ManualTimer implements Timer {
+  bool _isActive = true;
+
+  @override
+  bool get isActive => _isActive;
+
+  @override
+  int get tick => 0;
+
+  @override
+  void cancel() => _isActive = false;
+}
+
+void main() {
+  group('TempoCueScheduler', () {
+    test('schedules cues against absolute elapsed time to avoid drift', () {
+      final clock = _FakeTempoClock();
+      final delays = <Duration>[];
+      final callbacks = <void Function()>[];
+      var cueCount = 0;
+
+      final scheduler = TempoCueScheduler(
+        clockFactory: () => clock,
+        timerFactory: (duration, callback) {
+          delays.add(duration);
+          callbacks.add(callback);
+          return _ManualTimer();
+        },
+      );
+
+      scheduler.start(
+        interval: const Duration(seconds: 1),
+        onCue: () => cueCount += 1,
+      );
+
+      expect(delays.single, const Duration(seconds: 1));
+
+      clock.elapsed = const Duration(milliseconds: 1050);
+      callbacks.removeAt(0)();
+
+      expect(cueCount, 1);
+      expect(delays.last, const Duration(milliseconds: 950));
+
+      clock.elapsed = const Duration(milliseconds: 2120);
+      callbacks.removeAt(0)();
+
+      expect(cueCount, 2);
+      expect(delays.last, const Duration(milliseconds: 880));
+
+      scheduler.stop();
+      expect(clock.started, isFalse);
+    });
+
+    test('does not accumulate callback delay across long sessions', () {
+      final clock = _FakeTempoClock();
+      final delays = <Duration>[];
+      final callbacks = <void Function()>[];
+      var cueCount = 0;
+
+      final scheduler = TempoCueScheduler(
+        clockFactory: () => clock,
+        timerFactory: (duration, callback) {
+          delays.add(duration);
+          callbacks.add(callback);
+          return _ManualTimer();
+        },
+      );
+
+      scheduler.start(
+        interval: const Duration(seconds: 1),
+        onCue: () => cueCount += 1,
+      );
+
+      for (var cue = 1; cue <= 600; cue += 1) {
+        clock.elapsed = Duration(seconds: cue, milliseconds: 20);
+        callbacks.removeAt(0)();
+      }
+
+      expect(cueCount, 600);
+      expect(delays.last, const Duration(milliseconds: 980));
+    });
+
+    test('uses an immediate catch-up delay when a cue is already due', () {
+      final clock = _FakeTempoClock();
+      final delays = <Duration>[];
+      final callbacks = <void Function()>[];
+
+      final scheduler = TempoCueScheduler(
+        clockFactory: () => clock,
+        timerFactory: (duration, callback) {
+          delays.add(duration);
+          callbacks.add(callback);
+          return _ManualTimer();
+        },
+      );
+
+      scheduler.start(
+        interval: const Duration(seconds: 1),
+        onCue: () {},
+      );
+
+      clock.elapsed = const Duration(milliseconds: 2500);
+      callbacks.removeAt(0)();
+
+      expect(delays.last, Duration.zero);
+    });
+  });
+}

--- a/test/features/tempo/tempo_trainer_provider_test.dart
+++ b/test/features/tempo/tempo_trainer_provider_test.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:rep_swim/features/tempo/domain/entities/tempo_mode.dart';
 import 'package:rep_swim/features/tempo/domain/entities/tempo_template.dart';
 import 'package:rep_swim/features/tempo/presentation/providers/tempo_cue_player.dart';
+import 'package:rep_swim/features/tempo/presentation/providers/tempo_cue_scheduler.dart';
 import 'package:rep_swim/features/tempo/presentation/providers/tempo_trainer_provider.dart';
 
 class _FakeTempoCuePlayer implements TempoCuePlayer {
@@ -17,13 +20,49 @@ class _FakeTempoCuePlayer implements TempoCuePlayer {
   }
 }
 
+class _FakeTempoClock implements TempoClock {
+  Duration _elapsed = Duration.zero;
+
+  @override
+  Duration get elapsed => _elapsed;
+
+  @override
+  void start() {}
+
+  @override
+  void stop() {}
+
+  @override
+  void reset() => _elapsed = Duration.zero;
+
+  void advance(Duration duration) {
+    _elapsed += duration;
+  }
+}
+
+TempoCueScheduler _fakeAsyncScheduler(_FakeTempoClock clock) {
+  return TempoCueScheduler(
+    clockFactory: () => clock,
+    timerFactory: (duration, callback) {
+      return Timer(duration, () {
+        clock.advance(duration);
+        callback();
+      });
+    },
+  );
+}
+
 void main() {
   group('TempoTrainerNotifier', () {
     test('plays audible/vibration cue on start and accents configured beats',
         () {
       fakeAsync((async) {
         final cuePlayer = _FakeTempoCuePlayer();
-        final notifier = TempoTrainerNotifier(cuePlayer);
+        final clock = _FakeTempoClock();
+        final notifier = TempoTrainerNotifier(
+          cuePlayer,
+          cueScheduler: _fakeAsyncScheduler(clock),
+        );
 
         notifier.configure(
           mode: TempoMode.strokeRate,


### PR DESCRIPTION
## Summary
- replace Tempo Trainer timer-periodic cue loop with an injectable stopwatch-backed one-shot scheduler
- keep sound, haptic, visual flash, and spoken cue behavior behind existing cue settings/player abstractions
- document the timing strategy and native audio-engine boundary

## Tests
- dart format lib test
- flutter test test/features/tempo/tempo_cue_scheduler_test.dart test/features/tempo/tempo_trainer_provider_test.dart
- flutter analyze
- flutter test

Closes #16