### PR TITLE
feat: add CSS pace tempo preset builder

### DIFF
--- a/docs/tempo-trainer.md
+++ b/docs/tempo-trainer.md
@@ -67,6 +67,20 @@ The screen exposes these inputs:
 All numeric configuration values must be positive. Invalid setup values show
 `Enter valid tempo values.` and are not applied.
 
+## CSS Pace Builder
+
+The CSS Pace Builder accepts recent 200m and 400m times in seconds. It calculates
+critical swim speed from the difference between those times, then derives:
+
+- CSS pace per 100m.
+- 25m cue target.
+- 50m cue target.
+
+The builder saves the calculated pace as a reusable Lap Pace tempo template. CSS
+templates use a 100m target distance, the calculated pace as target time, and the
+current pool length and cue output settings. Invalid or impossible inputs are not
+saved.
+
 ## Cue Outputs
 
 Cue output settings are configured with chips:
@@ -191,7 +205,6 @@ The MVP intentionally does not include:
 
 - Low-drift audio scheduling.
 - Saved session history/detail screens.
-- CSS pace preset generation.
 - Stroke-rate ramp tests.
 - USRPT race-pace presets and fail counters.
 - Per-rep or per-segment race modelling.
@@ -201,6 +214,5 @@ Follow-up issues:
 
 - #15 Tempo session history/detail views.
 - #16 Low-drift audio scheduling.
-- #17 CSS pace preset builder.
 - #18 USRPT race-pace preset with fail counter.
 - #19 Stroke-rate ramp test preset.

--- a/lib/features/tempo/domain/services/css_pace_calculator.dart
+++ b/lib/features/tempo/domain/services/css_pace_calculator.dart
@@ -1,0 +1,44 @@
+class CssPacePreset {
+  const CssPacePreset({
+    required this.cssMetersPerSecond,
+    required this.pacePer100,
+    required this.split25,
+    required this.split50,
+  });
+
+  final double cssMetersPerSecond;
+  final Duration pacePer100;
+  final Duration split25;
+  final Duration split50;
+}
+
+class CssPaceCalculator {
+  const CssPaceCalculator();
+
+  CssPacePreset calculate({
+    required Duration time200,
+    required Duration time400,
+  }) {
+    if (time200 <= Duration.zero || time400 <= Duration.zero) {
+      throw ArgumentError('CSS times must be positive.');
+    }
+    if (time400 <= time200) {
+      throw ArgumentError('400m time must be slower than 200m time.');
+    }
+    if (time400 <= time200 * 2) {
+      throw ArgumentError('400m pace must be slower than 200m pace.');
+    }
+
+    final deltaMicroseconds = time400.inMicroseconds - time200.inMicroseconds;
+    final cssMetersPerSecond =
+        200 * Duration.microsecondsPerSecond / deltaMicroseconds;
+    final pacePer100 = Duration(microseconds: (deltaMicroseconds / 2).round());
+
+    return CssPacePreset(
+      cssMetersPerSecond: cssMetersPerSecond,
+      pacePer100: pacePer100,
+      split25: Duration(microseconds: (pacePer100.inMicroseconds / 4).round()),
+      split50: Duration(microseconds: (pacePer100.inMicroseconds / 2).round()),
+    );
+  }
+}

--- a/lib/features/tempo/presentation/providers/tempo_template_providers.dart
+++ b/lib/features/tempo/presentation/providers/tempo_template_providers.dart
@@ -8,8 +8,10 @@ import '../../../../database/daos/sync_queue_dao.dart';
 import '../../../../database/daos/training_template_dao.dart';
 import '../../../profiles/presentation/providers/profile_providers.dart';
 import '../../../templates/presentation/providers/training_template_providers.dart';
+import '../../domain/entities/tempo_mode.dart';
 import '../../domain/entities/tempo_session_result.dart';
 import '../../domain/entities/tempo_template.dart';
+import '../../domain/services/css_pace_calculator.dart';
 import 'tempo_trainer_provider.dart';
 
 const _uuid = Uuid();
@@ -52,6 +54,41 @@ class TempoTemplatesNotifier
       profileId: _profileId,
       name: name.trim(),
       now: now,
+    );
+    await _dao.insertTempoTemplate(template);
+    await _queueChange(
+      entityType: 'tempo_template',
+      entityId: template.id,
+      operation: SyncOperation.create,
+      payload: tempoTemplatePayload(template),
+    );
+    await load();
+    return template;
+  }
+
+  Future<TempoTemplate> saveCssPacePreset({
+    required String name,
+    required CssPacePreset preset,
+    required int poolLengthMeters,
+    required double strokeRate,
+    required int breathEveryStrokes,
+    required TempoCueSettings cueSettings,
+  }) async {
+    final now = DateTime.now().toUtc();
+    final template = TempoTemplate(
+      id: _uuid.v4(),
+      profileId: _profileId,
+      name: name.trim(),
+      mode: TempoMode.lapPace,
+      poolLengthMeters: poolLengthMeters,
+      targetDistanceMeters: 100,
+      targetTime: preset.pacePer100,
+      strokeRate: strokeRate,
+      breathEveryStrokes: breathEveryStrokes,
+      cueSettings: cueSettings,
+      safetyWarningAcknowledged: false,
+      createdAt: now,
+      updatedAt: now,
     );
     await _dao.insertTempoTemplate(template);
     await _queueChange(

--- a/lib/features/tempo/presentation/screens/tempo_trainer_screen.dart
+++ b/lib/features/tempo/presentation/screens/tempo_trainer_screen.dart
@@ -6,6 +6,7 @@ import '../../../../core/utils/duration_utils.dart';
 import '../../domain/entities/tempo_mode.dart';
 import '../../domain/entities/tempo_session_result.dart';
 import '../../domain/entities/tempo_template.dart';
+import '../../domain/services/css_pace_calculator.dart';
 import '../../domain/services/tempo_calculator.dart';
 import '../../domain/services/tempo_csv_exporter.dart';
 import '../providers/tempo_template_providers.dart';
@@ -25,6 +26,9 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
   late final TextEditingController _strokeRateController;
   late final TextEditingController _breathEveryController;
   late final TextEditingController _accentEveryController;
+  late final TextEditingController _css200Controller;
+  late final TextEditingController _css400Controller;
+  late final TextEditingController _cssNameController;
   late final TextEditingController _splitsController;
   late final TextEditingController _strokeCountsController;
   late final TextEditingController _rpeController;
@@ -46,6 +50,9 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
         TextEditingController(text: state.breathEveryStrokes.toString());
     _accentEveryController =
         TextEditingController(text: state.cueSettings.accentEvery.toString());
+    _css200Controller = TextEditingController();
+    _css400Controller = TextEditingController();
+    _cssNameController = TextEditingController(text: 'CSS pace');
     _splitsController = TextEditingController();
     _strokeCountsController = TextEditingController();
     _rpeController = TextEditingController();
@@ -60,6 +67,9 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
     _strokeRateController.dispose();
     _breathEveryController.dispose();
     _accentEveryController.dispose();
+    _css200Controller.dispose();
+    _css400Controller.dispose();
+    _cssNameController.dispose();
     _splitsController.dispose();
     _strokeCountsController.dispose();
     _rpeController.dispose();
@@ -132,6 +142,63 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
         .saveFromState(name, ref.read(tempoTrainerProvider));
     if (!mounted) return;
     _showSnack('Saved ${saved.name}.');
+  }
+
+  CssPacePreset? _currentCssPreset() {
+    final time200 = _parseSecondsDuration(_css200Controller.text);
+    final time400 = _parseSecondsDuration(_css400Controller.text);
+    if (time200 == null || time400 == null) return null;
+    try {
+      return const CssPaceCalculator().calculate(
+        time200: time200,
+        time400: time400,
+      );
+    } on ArgumentError {
+      return null;
+    }
+  }
+
+  Duration? _parseSecondsDuration(String value) {
+    final seconds = double.tryParse(value.trim());
+    if (seconds == null || seconds <= 0) return null;
+    return Duration(milliseconds: (seconds * 1000).round());
+  }
+
+  Future<void> _createCssTemplate(TempoTrainerState state) async {
+    final time200 = _parseSecondsDuration(_css200Controller.text);
+    final time400 = _parseSecondsDuration(_css400Controller.text);
+    if (time200 == null || time400 == null) {
+      _showSnack('Enter valid 200m and 400m times.');
+      return;
+    }
+
+    final CssPacePreset preset;
+    try {
+      preset = const CssPaceCalculator().calculate(
+        time200: time200,
+        time400: time400,
+      );
+    } on ArgumentError {
+      _showSnack('Enter possible 200m and 400m times.');
+      return;
+    }
+
+    final name = _cssNameController.text.trim().isEmpty
+        ? 'CSS pace'
+        : _cssNameController.text.trim();
+    final saved =
+        await ref.read(tempoTemplatesProvider.notifier).saveCssPacePreset(
+              name: name,
+              preset: preset,
+              poolLengthMeters: state.poolLengthMeters,
+              strokeRate: state.strokeRate,
+              breathEveryStrokes: state.breathEveryStrokes,
+              cueSettings: state.cueSettings,
+            );
+    if (!mounted) return;
+    ref.read(tempoTrainerProvider.notifier).loadTemplate(saved);
+    _syncControllers(ref.read(tempoTrainerProvider));
+    _showSnack('Created ${saved.name}.');
   }
 
   Future<void> _saveSessionResult(TempoTrainerState state) async {
@@ -250,6 +317,7 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
     final notifier = ref.read(tempoTrainerProvider.notifier);
     final templatesAsync = ref.watch(tempoTemplatesProvider);
     final resultsAsync = ref.watch(tempoSessionResultsProvider);
+    final cssPreset = _currentCssPreset();
 
     ref.listen(tempoTrainerProvider, (_, next) {
       if (!next.flashActive) return;
@@ -317,6 +385,16 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
                       safetyWarningAcknowledged: value,
                     );
               },
+            ),
+            const SizedBox(height: 16),
+            _CssPaceBuilderPanel(
+              enabled: !state.isRunning,
+              css200Controller: _css200Controller,
+              css400Controller: _css400Controller,
+              nameController: _cssNameController,
+              preset: cssPreset,
+              onChanged: () => setState(() {}),
+              onCreate: () => _createCssTemplate(state),
             ),
             const SizedBox(height: 16),
             _RunPanel(
@@ -535,6 +613,106 @@ class _TempoConfigPanel extends StatelessWidget {
                 onPressed: state.isRunning ? null : onApply,
                 icon: const Icon(Icons.check),
                 label: const Text('Apply'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CssPaceBuilderPanel extends StatelessWidget {
+  const _CssPaceBuilderPanel({
+    required this.enabled,
+    required this.css200Controller,
+    required this.css400Controller,
+    required this.nameController,
+    required this.preset,
+    required this.onChanged,
+    required this.onCreate,
+  });
+
+  final bool enabled;
+  final TextEditingController css200Controller;
+  final TextEditingController css400Controller;
+  final TextEditingController nameController;
+  final CssPacePreset? preset;
+  final VoidCallback onChanged;
+  final VoidCallback onCreate;
+
+  @override
+  Widget build(BuildContext context) {
+    final currentPreset = preset;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'CSS Pace Builder',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: [
+                _NumberField(
+                  controller: css200Controller,
+                  label: '200m sec',
+                  enabled: enabled,
+                  decimal: true,
+                  onChanged: (_) => onChanged(),
+                ),
+                _NumberField(
+                  controller: css400Controller,
+                  label: '400m sec',
+                  enabled: enabled,
+                  decimal: true,
+                  onChanged: (_) => onChanged(),
+                ),
+                SizedBox(
+                  width: 180,
+                  child: TextField(
+                    controller: nameController,
+                    enabled: enabled,
+                    decoration: const InputDecoration(
+                      labelText: 'CSS template',
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            if (currentPreset != null) ...[
+              const SizedBox(height: 12),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  _MetricChip(
+                    label:
+                        '${DurationUtils.formatDuration(currentPreset.pacePer100)}/100m',
+                  ),
+                  _MetricChip(
+                    label:
+                        '25m ${DurationUtils.formatDurationWithCentiseconds(currentPreset.split25)}',
+                  ),
+                  _MetricChip(
+                    label:
+                        '50m ${DurationUtils.formatDurationWithCentiseconds(currentPreset.split50)}',
+                  ),
+                ],
+              ),
+            ],
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton.icon(
+                onPressed: enabled ? onCreate : null,
+                icon: const Icon(Icons.add_task),
+                label: const Text('Create CSS Template'),
               ),
             ),
           ],
@@ -788,18 +966,34 @@ class _ResultPanel extends StatelessWidget {
   }
 }
 
+class _MetricChip extends StatelessWidget {
+  const _MetricChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Chip(
+      avatar: const Icon(Icons.speed, size: 16),
+      label: Text(label),
+    );
+  }
+}
+
 class _NumberField extends StatelessWidget {
   const _NumberField({
     required this.controller,
     required this.label,
     required this.enabled,
     this.decimal = false,
+    this.onChanged,
   });
 
   final TextEditingController controller;
   final String label;
   final bool enabled;
   final bool decimal;
+  final ValueChanged<String>? onChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -810,6 +1004,7 @@ class _NumberField extends StatelessWidget {
         enabled: enabled,
         decoration: InputDecoration(labelText: label),
         keyboardType: TextInputType.numberWithOptions(decimal: decimal),
+        onChanged: onChanged,
       ),
     );
   }

--- a/test/features/tempo/tempo_calculator_test.dart
+++ b/test/features/tempo/tempo_calculator_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/tempo/domain/services/css_pace_calculator.dart';
 import 'package:rep_swim/features/tempo/domain/services/tempo_calculator.dart';
 
 void main() {
@@ -54,6 +55,46 @@ void main() {
     test('flags high breath intervals for safety acknowledgement', () {
       expect(calculator.requiresBreathSafetyWarning(4), isFalse);
       expect(calculator.requiresBreathSafetyWarning(5), isTrue);
+    });
+  });
+
+  group('CssPaceCalculator', () {
+    const calculator = CssPaceCalculator();
+
+    test('calculates CSS pace and pool split targets', () {
+      final preset = calculator.calculate(
+        time200: const Duration(minutes: 2, seconds: 30),
+        time400: const Duration(minutes: 5, seconds: 20),
+      );
+
+      expect(preset.pacePer100, const Duration(seconds: 85));
+      expect(preset.split25, const Duration(milliseconds: 21250));
+      expect(preset.split50, const Duration(milliseconds: 42500));
+      expect(preset.cssMetersPerSecond, closeTo(1.176, 0.001));
+    });
+
+    test('rejects missing or impossible CSS times', () {
+      expect(
+        () => calculator.calculate(
+          time200: Duration.zero,
+          time400: const Duration(minutes: 5),
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => calculator.calculate(
+          time200: const Duration(minutes: 5),
+          time400: const Duration(minutes: 4),
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => calculator.calculate(
+          time200: const Duration(minutes: 2, seconds: 30),
+          time400: const Duration(minutes: 4, seconds: 40),
+        ),
+        throwsArgumentError,
+      );
     });
   });
 }

--- a/test/features/tempo/tempo_template_providers_test.dart
+++ b/test/features/tempo/tempo_template_providers_test.dart
@@ -6,6 +6,7 @@ import 'package:rep_swim/database/daos/training_template_dao.dart';
 import 'package:rep_swim/features/tempo/domain/entities/tempo_mode.dart';
 import 'package:rep_swim/features/tempo/domain/entities/tempo_session_result.dart';
 import 'package:rep_swim/features/tempo/domain/entities/tempo_template.dart';
+import 'package:rep_swim/features/tempo/domain/services/css_pace_calculator.dart';
 import 'package:rep_swim/features/tempo/presentation/providers/tempo_template_providers.dart';
 import 'package:rep_swim/features/tempo/presentation/providers/tempo_trainer_provider.dart';
 
@@ -141,6 +142,59 @@ void main() {
           entityType: 'tempo_template',
           entityId: 'tempo-template-1',
           operation: SyncOperation.delete,
+          payload: any(named: 'payload'),
+        ),
+      ).called(1);
+    });
+
+    test('saves CSS pace preset as a lap pace template', () async {
+      final dao = _MockTrainingTemplateDao();
+      final queue = _MockSyncQueueDao();
+      when(() => dao.getTempoTemplates(any())).thenAnswer((_) async => []);
+      when(() => dao.insertTempoTemplate(any())).thenAnswer((_) async {});
+      when(
+        () => queue.enqueue(
+          profileId: any(named: 'profileId'),
+          entityType: any(named: 'entityType'),
+          entityId: any(named: 'entityId'),
+          operation: any(named: 'operation'),
+          payload: any(named: 'payload'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final notifier = TempoTemplatesNotifier(
+        dao,
+        'profile-1',
+        syncQueueDao: queue,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final preset = const CssPaceCalculator().calculate(
+        time200: const Duration(minutes: 2, seconds: 30),
+        time400: const Duration(minutes: 5, seconds: 20),
+      );
+      final saved = await notifier.saveCssPacePreset(
+        name: ' CSS test ',
+        preset: preset,
+        poolLengthMeters: 25,
+        strokeRate: 70,
+        breathEveryStrokes: 3,
+        cueSettings: const TempoCueSettings(visualFlash: false),
+      );
+
+      expect(saved.name, 'CSS test');
+      expect(saved.mode, TempoMode.lapPace);
+      expect(saved.targetDistanceMeters, 100);
+      expect(saved.targetTime, const Duration(seconds: 85));
+      expect(saved.poolLengthMeters, 25);
+      expect(saved.cueSettings.visualFlash, isFalse);
+      verify(() => dao.insertTempoTemplate(any())).called(1);
+      verify(
+        () => queue.enqueue(
+          profileId: 'profile-1',
+          entityType: 'tempo_template',
+          entityId: saved.id,
+          operation: SyncOperation.create,
           payload: any(named: 'payload'),
         ),
       ).called(1);

--- a/test/features/tempo/tempo_trainer_screen_test.dart
+++ b/test/features/tempo/tempo_trainer_screen_test.dart
@@ -133,7 +133,7 @@ void main() {
       expect(find.text('Vibration'), findsOneWidget);
       expect(find.text('Visual flash'), findsOneWidget);
 
-      await tester.ensureVisible(find.widgetWithText(FilledButton, 'Start'));
+      await _scrollTo(tester, find.widgetWithText(FilledButton, 'Start'));
       await tester.pumpAndSettle();
       await tester.tap(find.widgetWithText(FilledButton, 'Start'));
       await tester.pump();
@@ -159,6 +159,7 @@ void main() {
       await tester.pump();
 
       expect(find.text('Breath safety acknowledged'), findsOneWidget);
+      await _scrollTo(tester, find.widgetWithText(FilledButton, 'Start'));
       final startButton = tester.widget<FilledButton>(
         find.widgetWithText(FilledButton, 'Start'),
       );
@@ -202,6 +203,82 @@ void main() {
 
       verify(() => harness.dao.insertTempoTemplate(any())).called(1);
       expect(find.text('Saved Threshold tempo.'), findsOneWidget);
+    });
+
+    testWidgets('creates a CSS lap pace template from 200m and 400m times',
+        (tester) async {
+      final harness = await _pumpTempoTrainer(tester);
+
+      await _scrollTo(
+        tester,
+        find.widgetWithText(TextField, '200m sec'),
+      );
+      await tester.enterText(find.widgetWithText(TextField, '200m sec'), '150');
+      await tester.enterText(find.widgetWithText(TextField, '400m sec'), '320');
+      await tester.enterText(
+        find.widgetWithText(TextField, 'CSS template'),
+        'CSS threshold',
+      );
+      await tester.pump();
+
+      expect(find.text('1:25/100m'), findsOneWidget);
+      expect(find.text('25m 00:21.25'), findsOneWidget);
+      expect(find.text('50m 00:42.50'), findsOneWidget);
+
+      await _scrollTo(
+        tester,
+        find.widgetWithText(FilledButton, 'Create CSS Template'),
+      );
+      await tester
+          .tap(find.widgetWithText(FilledButton, 'Create CSS Template'));
+      await tester.pumpAndSettle();
+
+      final captured = verify(
+        () => harness.dao.insertTempoTemplate(captureAny()),
+      ).captured.single as TempoTemplate;
+      expect(captured.name, 'CSS threshold');
+      expect(captured.mode, TempoMode.lapPace);
+      expect(captured.targetDistanceMeters, 100);
+      expect(captured.targetTime, const Duration(seconds: 85));
+      expect(find.text('Created CSS threshold.'), findsOneWidget);
+    });
+
+    testWidgets('validates missing CSS times', (tester) async {
+      await _pumpTempoTrainer(tester);
+
+      await _scrollTo(
+        tester,
+        find.widgetWithText(FilledButton, 'Create CSS Template'),
+      );
+      await tester.drag(find.byType(Scrollable).first, const Offset(0, 100));
+      await tester.pumpAndSettle();
+      await tester
+          .tap(find.widgetWithText(FilledButton, 'Create CSS Template'));
+      await tester.pump();
+
+      expect(find.text('Enter valid 200m and 400m times.'), findsOneWidget);
+    });
+
+    testWidgets('validates impossible CSS times', (tester) async {
+      await _pumpTempoTrainer(tester);
+
+      await _scrollTo(
+        tester,
+        find.widgetWithText(TextField, '200m sec'),
+      );
+      await tester.enterText(find.widgetWithText(TextField, '200m sec'), '300');
+      await tester.enterText(find.widgetWithText(TextField, '400m sec'), '240');
+      await _scrollTo(
+        tester,
+        find.widgetWithText(FilledButton, 'Create CSS Template'),
+      );
+      await tester.drag(find.byType(Scrollable).first, const Offset(0, 100));
+      await tester.pumpAndSettle();
+      await tester
+          .tap(find.widgetWithText(FilledButton, 'Create CSS Template'));
+      await tester.pump();
+
+      expect(find.text('Enter possible 200m and 400m times.'), findsOneWidget);
     });
 
     testWidgets('saves a tempo result with actual splits', (tester) async {


### PR DESCRIPTION
## Summary
- add CSS pace calculation from 200m and 400m times with 25m/50m split targets
- add Tempo Trainer CSS builder UI that persists calculated lap pace templates offline
- validate missing and impossible CSS inputs and document the feature

## Tests
- dart format lib test
- flutter test test/features/tempo
- flutter analyze
- flutter test

Closes #17