### PR TITLE
feat: add USRPT race pace trainer

### DIFF
--- a/docs/tempo-trainer.md
+++ b/docs/tempo-trainer.md
@@ -67,6 +67,27 @@ The screen exposes these inputs:
 All numeric configuration values must be positive. Invalid setup values show
 `Enter valid tempo values.` and are not applied.
 
+## USRPT Race Pace
+
+The USRPT Race Pace panel builds repeat targets from an event distance and event
+target time. It accepts:
+
+- `Event m`: race distance.
+- `Event sec`: race target time in seconds.
+- `Repeat m`: repetition distance.
+- `Rest sec`: rest between repetitions.
+- `Fail rule`: number of failed repetitions that stops the set.
+
+The panel calculates the repetition target split from the event pace, shows the
+rest countdown, and records each repetition as pass or fail. When the fail rule
+is reached, pass/fail logging stops and the panel shows a fail-rule warning.
+Applying USRPT also configures the live Lap Pace cue interval for the repeat
+split, using the current sound, vibration, visual flash, and voice settings.
+
+USRPT results save through the same offline tempo result store. Saved USRPT
+results are profile-scoped, use Lap Pace mode, store pass/fail outcomes in the
+saved result notes, and include structured metadata in the queued sync payload.
+
 ## Cue Outputs
 
 Cue output settings are configured with chips:
@@ -193,7 +214,6 @@ The MVP intentionally does not include:
 - Saved session history/detail screens.
 - CSS pace preset generation.
 - Stroke-rate ramp tests.
-- USRPT race-pace presets and fail counters.
 - Per-rep or per-segment race modelling.
 - Wearable, Bluetooth, or external device integration.
 
@@ -202,5 +222,4 @@ Follow-up issues:
 - #15 Tempo session history/detail views.
 - #16 Low-drift audio scheduling.
 - #17 CSS pace preset builder.
-- #18 USRPT race-pace preset with fail counter.
 - #19 Stroke-rate ramp test preset.

--- a/lib/core/sync/sync_payloads.dart
+++ b/lib/core/sync/sync_payloads.dart
@@ -162,6 +162,7 @@ Map<String, Object?> tempoSessionResultPayload(TempoSessionResult result) {
     'strokeCounts': result.strokeCounts,
     'rpe': result.rpe,
     'notes': result.notes,
+    'metadata': result.metadata,
   };
 }
 

--- a/lib/features/tempo/domain/entities/tempo_session_result.dart
+++ b/lib/features/tempo/domain/entities/tempo_session_result.dart
@@ -34,6 +34,7 @@ class TempoSessionResult {
     this.completedAt,
     this.rpe,
     this.notes,
+    this.metadata = const <String, Object?>{},
   });
 
   final String id;
@@ -50,4 +51,5 @@ class TempoSessionResult {
   final List<int> strokeCounts;
   final int? rpe;
   final String? notes;
+  final Map<String, Object?> metadata;
 }

--- a/lib/features/tempo/domain/services/usrpt_calculator.dart
+++ b/lib/features/tempo/domain/services/usrpt_calculator.dart
@@ -1,0 +1,67 @@
+class UsrptRacePacePreset {
+  const UsrptRacePacePreset({
+    required this.eventDistanceMeters,
+    required this.eventTargetTime,
+    required this.repetitionDistanceMeters,
+    required this.repetitionTargetTime,
+    required this.restDuration,
+    required this.failLimit,
+  });
+
+  final int eventDistanceMeters;
+  final Duration eventTargetTime;
+  final int repetitionDistanceMeters;
+  final Duration repetitionTargetTime;
+  final Duration restDuration;
+  final int failLimit;
+
+  double get repetitionsPerRace =>
+      eventDistanceMeters / repetitionDistanceMeters;
+}
+
+class UsrptRepOutcome {
+  const UsrptRepOutcome({
+    required this.index,
+    required this.passed,
+  });
+
+  final int index;
+  final bool passed;
+
+  String get label => passed ? 'P' : 'F';
+}
+
+class UsrptRacePaceCalculator {
+  const UsrptRacePaceCalculator();
+
+  UsrptRacePacePreset calculate({
+    required int eventDistanceMeters,
+    required Duration eventTargetTime,
+    required int repetitionDistanceMeters,
+    required Duration restDuration,
+    required int failLimit,
+  }) {
+    if (eventDistanceMeters <= 0 ||
+        repetitionDistanceMeters <= 0 ||
+        eventTargetTime <= Duration.zero ||
+        restDuration < Duration.zero ||
+        failLimit <= 0) {
+      throw ArgumentError('USRPT values must be positive.');
+    }
+    if (repetitionDistanceMeters > eventDistanceMeters) {
+      throw ArgumentError('Repeat distance cannot exceed event distance.');
+    }
+
+    final ratio = repetitionDistanceMeters / eventDistanceMeters;
+    return UsrptRacePacePreset(
+      eventDistanceMeters: eventDistanceMeters,
+      eventTargetTime: eventTargetTime,
+      repetitionDistanceMeters: repetitionDistanceMeters,
+      repetitionTargetTime: Duration(
+        microseconds: (eventTargetTime.inMicroseconds * ratio).round(),
+      ),
+      restDuration: restDuration,
+      failLimit: failLimit,
+    );
+  }
+}

--- a/lib/features/tempo/presentation/providers/tempo_template_providers.dart
+++ b/lib/features/tempo/presentation/providers/tempo_template_providers.dart
@@ -8,8 +8,10 @@ import '../../../../database/daos/sync_queue_dao.dart';
 import '../../../../database/daos/training_template_dao.dart';
 import '../../../profiles/presentation/providers/profile_providers.dart';
 import '../../../templates/presentation/providers/training_template_providers.dart';
+import '../../domain/entities/tempo_mode.dart';
 import '../../domain/entities/tempo_session_result.dart';
 import '../../domain/entities/tempo_template.dart';
+import '../../domain/services/usrpt_calculator.dart';
 import 'tempo_trainer_provider.dart';
 
 const _uuid = Uuid();
@@ -159,6 +161,74 @@ class TempoSessionResultsNotifier
       strokeCounts: strokeCounts,
       rpe: rpe,
       notes: (notes?.trim().isEmpty ?? true) ? null : notes!.trim(),
+    );
+    await _dao.insertTempoSessionResult(result);
+    await _queueChange(
+      entityType: 'tempo_session_result',
+      entityId: result.id,
+      operation: SyncOperation.create,
+      payload: tempoSessionResultPayload(result),
+    );
+    await load();
+    return result;
+  }
+
+  Future<TempoSessionResult> saveUsrptResult({
+    required UsrptRacePacePreset preset,
+    required List<UsrptRepOutcome> outcomes,
+    String? notes,
+  }) async {
+    final now = DateTime.now().toUtc();
+    final passCount = outcomes.where((outcome) => outcome.passed).length;
+    final failCount = outcomes.length - passCount;
+    final outcomeLabels = [
+      for (final outcome in outcomes) '${outcome.index}:${outcome.label}',
+    ];
+    final summary = 'USRPT ${preset.eventDistanceMeters}m target '
+        '${preset.eventTargetTime.inMilliseconds}ms; '
+        'repeat ${preset.repetitionDistanceMeters}m target '
+        '${preset.repetitionTargetTime.inMilliseconds}ms; '
+        'rest ${preset.restDuration.inSeconds}s; '
+        'fail rule ${preset.failLimit}; outcomes ${outcomeLabels.join(',')}';
+    final trimmedNotes = notes?.trim();
+    final result = TempoSessionResult(
+      id: _uuid.v4(),
+      profileId: _profileId,
+      mode: TempoMode.lapPace,
+      startedAt: now,
+      completedAt: now,
+      targetDistanceMeters: preset.repetitionDistanceMeters,
+      poolLengthMeters: preset.repetitionDistanceMeters,
+      targetTime: preset.repetitionTargetTime,
+      targetStrokeRate: 0,
+      actualSplits: [
+        for (final _ in outcomes) preset.repetitionTargetTime,
+      ],
+      strokeCounts: [
+        for (final outcome in outcomes) outcome.passed ? 1 : 0,
+      ],
+      notes: (trimmedNotes == null || trimmedNotes.isEmpty)
+          ? summary
+          : '$summary\n$trimmedNotes',
+      metadata: {
+        'type': 'usrpt',
+        'eventDistanceMeters': preset.eventDistanceMeters,
+        'eventTargetTimeMilliseconds': preset.eventTargetTime.inMilliseconds,
+        'repetitionDistanceMeters': preset.repetitionDistanceMeters,
+        'repetitionTargetTimeMilliseconds':
+            preset.repetitionTargetTime.inMilliseconds,
+        'restSeconds': preset.restDuration.inSeconds,
+        'failLimit': preset.failLimit,
+        'outcomes': [
+          for (final outcome in outcomes)
+            {
+              'index': outcome.index,
+              'passed': outcome.passed,
+            },
+        ],
+        'passCount': passCount,
+        'failCount': failCount,
+      },
     );
     await _dao.insertTempoSessionResult(result);
     await _queueChange(

--- a/lib/features/tempo/presentation/providers/usrpt_session_provider.dart
+++ b/lib/features/tempo/presentation/providers/usrpt_session_provider.dart
@@ -1,0 +1,146 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/services/usrpt_calculator.dart';
+
+class UsrptSessionState {
+  const UsrptSessionState({
+    this.eventDistanceMeters = 100,
+    this.eventTargetTime = const Duration(seconds: 60),
+    this.repetitionDistanceMeters = 25,
+    this.restDuration = const Duration(seconds: 20),
+    this.failLimit = 3,
+    this.outcomes = const [],
+    this.restRemaining = Duration.zero,
+    this.lastStatus = 'Ready',
+    this.failRuleReached = false,
+  });
+
+  final int eventDistanceMeters;
+  final Duration eventTargetTime;
+  final int repetitionDistanceMeters;
+  final Duration restDuration;
+  final int failLimit;
+  final List<UsrptRepOutcome> outcomes;
+  final Duration restRemaining;
+  final String lastStatus;
+  final bool failRuleReached;
+
+  UsrptRacePacePreset get preset => const UsrptRacePaceCalculator().calculate(
+        eventDistanceMeters: eventDistanceMeters,
+        eventTargetTime: eventTargetTime,
+        repetitionDistanceMeters: repetitionDistanceMeters,
+        restDuration: restDuration,
+        failLimit: failLimit,
+      );
+
+  int get nextRep => outcomes.length + 1;
+  int get passCount => outcomes.where((outcome) => outcome.passed).length;
+  int get failCount => outcomes.where((outcome) => !outcome.passed).length;
+
+  UsrptSessionState copyWith({
+    int? eventDistanceMeters,
+    Duration? eventTargetTime,
+    int? repetitionDistanceMeters,
+    Duration? restDuration,
+    int? failLimit,
+    List<UsrptRepOutcome>? outcomes,
+    Duration? restRemaining,
+    String? lastStatus,
+    bool? failRuleReached,
+  }) {
+    return UsrptSessionState(
+      eventDistanceMeters: eventDistanceMeters ?? this.eventDistanceMeters,
+      eventTargetTime: eventTargetTime ?? this.eventTargetTime,
+      repetitionDistanceMeters:
+          repetitionDistanceMeters ?? this.repetitionDistanceMeters,
+      restDuration: restDuration ?? this.restDuration,
+      failLimit: failLimit ?? this.failLimit,
+      outcomes: outcomes ?? this.outcomes,
+      restRemaining: restRemaining ?? this.restRemaining,
+      lastStatus: lastStatus ?? this.lastStatus,
+      failRuleReached: failRuleReached ?? this.failRuleReached,
+    );
+  }
+}
+
+class UsrptSessionNotifier extends StateNotifier<UsrptSessionState> {
+  UsrptSessionNotifier() : super(const UsrptSessionState());
+
+  void configure({
+    required int eventDistanceMeters,
+    required Duration eventTargetTime,
+    required int repetitionDistanceMeters,
+    required Duration restDuration,
+    required int failLimit,
+  }) {
+    const UsrptRacePaceCalculator().calculate(
+      eventDistanceMeters: eventDistanceMeters,
+      eventTargetTime: eventTargetTime,
+      repetitionDistanceMeters: repetitionDistanceMeters,
+      restDuration: restDuration,
+      failLimit: failLimit,
+    );
+    state = state.copyWith(
+      eventDistanceMeters: eventDistanceMeters,
+      eventTargetTime: eventTargetTime,
+      repetitionDistanceMeters: repetitionDistanceMeters,
+      restDuration: restDuration,
+      failLimit: failLimit,
+      outcomes: const [],
+      restRemaining: Duration.zero,
+      lastStatus: 'Ready',
+      failRuleReached: false,
+    );
+  }
+
+  void logPass() => _logOutcome(passed: true);
+
+  void logFail() => _logOutcome(passed: false);
+
+  void tickRest(Duration elapsed) {
+    if (state.restRemaining <= Duration.zero || elapsed <= Duration.zero) {
+      return;
+    }
+    final nextRest = state.restRemaining - elapsed;
+    state = state.copyWith(
+      restRemaining: nextRest.isNegative ? Duration.zero : nextRest,
+    );
+  }
+
+  void resetOutcomes() {
+    state = state.copyWith(
+      outcomes: const [],
+      restRemaining: Duration.zero,
+      lastStatus: 'Ready',
+      failRuleReached: false,
+    );
+  }
+
+  void _logOutcome({required bool passed}) {
+    if (state.failRuleReached) return;
+
+    final outcomes = [
+      ...state.outcomes,
+      UsrptRepOutcome(index: state.nextRep, passed: passed),
+    ];
+    final failCount = outcomes.where((outcome) => !outcome.passed).length;
+    final reached = failCount >= state.failLimit;
+    final status = reached
+        ? 'Fail rule reached after $failCount fails.'
+        : passed
+            ? 'Rep ${outcomes.length} pass. Rest next.'
+            : 'Rep ${outcomes.length} fail. Rest next.';
+
+    state = state.copyWith(
+      outcomes: outcomes,
+      restRemaining: reached ? Duration.zero : state.restDuration,
+      lastStatus: status,
+      failRuleReached: reached,
+    );
+  }
+}
+
+final usrptSessionProvider =
+    StateNotifierProvider<UsrptSessionNotifier, UsrptSessionState>(
+  (ref) => UsrptSessionNotifier(),
+);

--- a/lib/features/tempo/presentation/screens/tempo_trainer_screen.dart
+++ b/lib/features/tempo/presentation/screens/tempo_trainer_screen.dart
@@ -513,6 +513,16 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
                   ref.read(usrptSessionProvider.notifier).tickRest(elapsed),
             ),
             const SizedBox(height: 16),
+            _CssPaceBuilderPanel(
+              enabled: !state.isRunning,
+              css200Controller: _css200Controller,
+              css400Controller: _css400Controller,
+              nameController: _cssNameController,
+              preset: cssPreset,
+              onChanged: () => setState(() {}),
+              onCreate: () => _createCssTemplate(state),
+            ),
+            const SizedBox(height: 16),
             _RunPanel(
               state: state,
               onStartPause: state.isRunning ? notifier.pause : notifier.start,

--- a/lib/features/tempo/presentation/screens/tempo_trainer_screen.dart
+++ b/lib/features/tempo/presentation/screens/tempo_trainer_screen.dart
@@ -10,6 +10,7 @@ import '../../domain/services/tempo_calculator.dart';
 import '../../domain/services/tempo_csv_exporter.dart';
 import '../providers/tempo_template_providers.dart';
 import '../providers/tempo_trainer_provider.dart';
+import '../providers/usrpt_session_provider.dart';
 
 class TempoTrainerScreen extends ConsumerStatefulWidget {
   const TempoTrainerScreen({super.key});
@@ -25,6 +26,12 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
   late final TextEditingController _strokeRateController;
   late final TextEditingController _breathEveryController;
   late final TextEditingController _accentEveryController;
+  late final TextEditingController _usrptEventDistanceController;
+  late final TextEditingController _usrptTargetTimeController;
+  late final TextEditingController _usrptRepeatDistanceController;
+  late final TextEditingController _usrptRestController;
+  late final TextEditingController _usrptFailLimitController;
+  late final TextEditingController _usrptNotesController;
   late final TextEditingController _splitsController;
   late final TextEditingController _strokeCountsController;
   late final TextEditingController _rpeController;
@@ -46,6 +53,18 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
         TextEditingController(text: state.breathEveryStrokes.toString());
     _accentEveryController =
         TextEditingController(text: state.cueSettings.accentEvery.toString());
+    final usrpt = ref.read(usrptSessionProvider);
+    _usrptEventDistanceController =
+        TextEditingController(text: usrpt.eventDistanceMeters.toString());
+    _usrptTargetTimeController =
+        TextEditingController(text: _secondsText(usrpt.eventTargetTime));
+    _usrptRepeatDistanceController =
+        TextEditingController(text: usrpt.repetitionDistanceMeters.toString());
+    _usrptRestController =
+        TextEditingController(text: _secondsText(usrpt.restDuration));
+    _usrptFailLimitController =
+        TextEditingController(text: usrpt.failLimit.toString());
+    _usrptNotesController = TextEditingController();
     _splitsController = TextEditingController();
     _strokeCountsController = TextEditingController();
     _rpeController = TextEditingController();
@@ -60,6 +79,12 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
     _strokeRateController.dispose();
     _breathEveryController.dispose();
     _accentEveryController.dispose();
+    _usrptEventDistanceController.dispose();
+    _usrptTargetTimeController.dispose();
+    _usrptRepeatDistanceController.dispose();
+    _usrptRestController.dispose();
+    _usrptFailLimitController.dispose();
+    _usrptNotesController.dispose();
     _splitsController.dispose();
     _strokeCountsController.dispose();
     _rpeController.dispose();
@@ -132,6 +157,67 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
         .saveFromState(name, ref.read(tempoTrainerProvider));
     if (!mounted) return;
     _showSnack('Saved ${saved.name}.');
+  }
+
+  void _applyUsrptConfig() {
+    final eventDistance = int.tryParse(_usrptEventDistanceController.text);
+    final targetSeconds = double.tryParse(_usrptTargetTimeController.text);
+    final repeatDistance = int.tryParse(_usrptRepeatDistanceController.text);
+    final restSeconds = double.tryParse(_usrptRestController.text);
+    final failLimit = int.tryParse(_usrptFailLimitController.text);
+
+    if (eventDistance == null ||
+        targetSeconds == null ||
+        repeatDistance == null ||
+        restSeconds == null ||
+        failLimit == null) {
+      _showSnack('Enter valid USRPT values.');
+      return;
+    }
+
+    try {
+      ref.read(usrptSessionProvider.notifier).configure(
+            eventDistanceMeters: eventDistance,
+            eventTargetTime:
+                Duration(milliseconds: (targetSeconds * 1000).round()),
+            repetitionDistanceMeters: repeatDistance,
+            restDuration: Duration(milliseconds: (restSeconds * 1000).round()),
+            failLimit: failLimit,
+          );
+    } on ArgumentError {
+      _showSnack('Enter possible USRPT values.');
+      return;
+    }
+    final preset = ref.read(usrptSessionProvider).preset;
+    final tempoState = ref.read(tempoTrainerProvider);
+    ref.read(tempoTrainerProvider.notifier).configure(
+          mode: TempoMode.lapPace,
+          poolLengthMeters: repeatDistance,
+          targetDistanceMeters: repeatDistance,
+          targetTime: preset.repetitionTargetTime,
+          strokeRate: tempoState.strokeRate,
+          breathEveryStrokes: tempoState.breathEveryStrokes,
+          cueSettings: tempoState.cueSettings,
+          safetyWarningAcknowledged: tempoState.safetyWarningAcknowledged,
+        );
+    _syncControllers(ref.read(tempoTrainerProvider));
+    _showSnack('Applied USRPT race pace.');
+    FocusScope.of(context).unfocus();
+  }
+
+  Future<void> _saveUsrptResult(UsrptSessionState usrpt) async {
+    if (usrpt.outcomes.isEmpty) {
+      _showSnack('Log at least one USRPT repetition.');
+      return;
+    }
+    final result =
+        await ref.read(tempoSessionResultsProvider.notifier).saveUsrptResult(
+              preset: usrpt.preset,
+              outcomes: usrpt.outcomes,
+              notes: _usrptNotesController.text,
+            );
+    if (!mounted) return;
+    _showSnack('Saved USRPT result with ${result.strokeCounts.length} reps.');
   }
 
   Future<void> _saveSessionResult(TempoTrainerState state) async {
@@ -250,6 +336,7 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
     final notifier = ref.read(tempoTrainerProvider.notifier);
     final templatesAsync = ref.watch(tempoTemplatesProvider);
     final resultsAsync = ref.watch(tempoSessionResultsProvider);
+    final usrpt = ref.watch(usrptSessionProvider);
 
     ref.listen(tempoTrainerProvider, (_, next) {
       if (!next.flashActive) return;
@@ -317,6 +404,25 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
                       safetyWarningAcknowledged: value,
                     );
               },
+            ),
+            const SizedBox(height: 16),
+            _UsrptPanel(
+              state: usrpt,
+              enabled: !state.isRunning,
+              eventDistanceController: _usrptEventDistanceController,
+              targetTimeController: _usrptTargetTimeController,
+              repeatDistanceController: _usrptRepeatDistanceController,
+              restController: _usrptRestController,
+              failLimitController: _usrptFailLimitController,
+              notesController: _usrptNotesController,
+              onApply: _applyUsrptConfig,
+              onPass: () => ref.read(usrptSessionProvider.notifier).logPass(),
+              onFail: () => ref.read(usrptSessionProvider.notifier).logFail(),
+              onSave: () => _saveUsrptResult(usrpt),
+              onReset: () =>
+                  ref.read(usrptSessionProvider.notifier).resetOutcomes(),
+              onRestTick: (elapsed) =>
+                  ref.read(usrptSessionProvider.notifier).tickRest(elapsed),
             ),
             const SizedBox(height: 16),
             _RunPanel(
@@ -536,6 +642,181 @@ class _TempoConfigPanel extends StatelessWidget {
                 icon: const Icon(Icons.check),
                 label: const Text('Apply'),
               ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _UsrptPanel extends StatelessWidget {
+  const _UsrptPanel({
+    required this.state,
+    required this.enabled,
+    required this.eventDistanceController,
+    required this.targetTimeController,
+    required this.repeatDistanceController,
+    required this.restController,
+    required this.failLimitController,
+    required this.notesController,
+    required this.onApply,
+    required this.onPass,
+    required this.onFail,
+    required this.onSave,
+    required this.onReset,
+    required this.onRestTick,
+  });
+
+  final UsrptSessionState state;
+  final bool enabled;
+  final TextEditingController eventDistanceController;
+  final TextEditingController targetTimeController;
+  final TextEditingController repeatDistanceController;
+  final TextEditingController restController;
+  final TextEditingController failLimitController;
+  final TextEditingController notesController;
+  final VoidCallback onApply;
+  final VoidCallback onPass;
+  final VoidCallback onFail;
+  final VoidCallback onSave;
+  final VoidCallback onReset;
+  final ValueChanged<Duration> onRestTick;
+
+  @override
+  Widget build(BuildContext context) {
+    final preset = state.preset;
+    final targetSplit = DurationUtils.formatDurationWithCentiseconds(
+      preset.repetitionTargetTime,
+    );
+    final rest = DurationUtils.formatDuration(state.restRemaining);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('USRPT Race Pace',
+                style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: [
+                _NumberField(
+                  controller: eventDistanceController,
+                  label: 'Event m',
+                  enabled: enabled,
+                ),
+                _NumberField(
+                  controller: targetTimeController,
+                  label: 'Event sec',
+                  enabled: enabled,
+                  decimal: true,
+                ),
+                _NumberField(
+                  controller: repeatDistanceController,
+                  label: 'Repeat m',
+                  enabled: enabled,
+                ),
+                _NumberField(
+                  controller: restController,
+                  label: 'Rest sec',
+                  enabled: enabled,
+                  decimal: true,
+                ),
+                _NumberField(
+                  controller: failLimitController,
+                  label: 'Fail rule',
+                  enabled: enabled,
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                _MetricChip(
+                    label: '${preset.repetitionDistanceMeters}m $targetSplit'),
+                _MetricChip(label: 'Rest ${preset.restDuration.inSeconds}s'),
+                _MetricChip(
+                    label: 'Fails ${state.failCount}/${state.failLimit}'),
+                _MetricChip(label: 'Passes ${state.passCount}'),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              state.failRuleReached
+                  ? state.lastStatus
+                  : '${state.lastStatus} · Next rep ${state.nextRep} · Rest $rest',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            if (state.outcomes.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 6,
+                runSpacing: 6,
+                children: [
+                  for (final outcome in state.outcomes)
+                    Chip(
+                      label: Text('${outcome.index}${outcome.label}'),
+                      avatar: Icon(
+                        outcome.passed
+                            ? Icons.check_circle_outline
+                            : Icons.cancel_outlined,
+                        size: 16,
+                      ),
+                    ),
+                ],
+              ),
+            ],
+            const SizedBox(height: 8),
+            TextField(
+              controller: notesController,
+              decoration: const InputDecoration(labelText: 'USRPT notes'),
+              minLines: 1,
+              maxLines: 2,
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              alignment: WrapAlignment.end,
+              children: [
+                OutlinedButton.icon(
+                  onPressed: enabled ? onApply : null,
+                  icon: const Icon(Icons.check),
+                  label: const Text('Apply USRPT'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: state.restRemaining > Duration.zero
+                      ? () => onRestTick(const Duration(seconds: 5))
+                      : null,
+                  icon: const Icon(Icons.hourglass_bottom),
+                  label: const Text('Rest -5s'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: state.outcomes.isEmpty ? null : onReset,
+                  icon: const Icon(Icons.refresh),
+                  label: const Text('Clear USRPT'),
+                ),
+                FilledButton.tonalIcon(
+                  onPressed: state.failRuleReached ? null : onPass,
+                  icon: const Icon(Icons.check_circle_outline),
+                  label: const Text('Pass Rep'),
+                ),
+                FilledButton.tonalIcon(
+                  onPressed: state.failRuleReached ? null : onFail,
+                  icon: const Icon(Icons.cancel_outlined),
+                  label: const Text('Fail Rep'),
+                ),
+                FilledButton.icon(
+                  onPressed: onSave,
+                  icon: const Icon(Icons.done_all),
+                  label: const Text('Save USRPT'),
+                ),
+              ],
             ),
           ],
         ),
@@ -784,6 +1065,20 @@ class _ResultPanel extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _MetricChip extends StatelessWidget {
+  const _MetricChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Chip(
+      avatar: const Icon(Icons.speed, size: 16),
+      label: Text(label),
     );
   }
 }

--- a/test/core/sync/sync_payloads_test.dart
+++ b/test/core/sync/sync_payloads_test.dart
@@ -223,6 +223,7 @@ void main() {
         'strokeCounts': [18, 19],
         'rpe': 7,
         'notes': 'Held rhythm',
+        'metadata': <String, Object?>{},
       });
     });
 

--- a/test/database/dao_integration_test.dart
+++ b/test/database/dao_integration_test.dart
@@ -256,11 +256,33 @@ void main() {
           strokeCounts: const [18],
         ),
       );
+      await dao.insertTempoSessionResult(
+        TempoSessionResult(
+          id: 'usrpt-result-1',
+          profileId: 'profile-1',
+          mode: TempoMode.lapPace,
+          startedAt: now.add(const Duration(minutes: 5)),
+          targetDistanceMeters: 25,
+          poolLengthMeters: 25,
+          targetTime: const Duration(seconds: 15),
+          targetStrokeRate: 0,
+          actualSplits: const [
+            Duration(seconds: 15),
+            Duration(seconds: 15),
+          ],
+          strokeCounts: const [1, 0],
+          notes: 'USRPT 100m target; outcomes 1:P,2:F',
+        ),
+      );
       final results = await dao.getTempoSessionResults('profile-1');
-      expect(results.single.templateId, template.id);
-      expect(results.single.actualSplits.last.inMilliseconds, 22400);
-      expect(results.single.strokeCounts, [18, 19]);
-      expect(results.single.notes, 'Held rhythm');
+      expect(results, hasLength(2));
+      expect(results.first.id, 'usrpt-result-1');
+      expect(results.first.strokeCounts, [1, 0]);
+      expect(results.first.notes, contains('outcomes 1:P,2:F'));
+      expect(results.last.templateId, template.id);
+      expect(results.last.actualSplits.last.inMilliseconds, 22400);
+      expect(results.last.strokeCounts, [18, 19]);
+      expect(results.last.notes, 'Held rhythm');
       expect(await dao.getTempoSessionResults('profile-2'), hasLength(1));
     });
 

--- a/test/database/dao_integration_test.dart
+++ b/test/database/dao_integration_test.dart
@@ -286,10 +286,7 @@ void main() {
       expect(await dao.getTempoSessionResults('profile-2'), hasLength(1));
 
       await dao.deleteTempoSessionResult('tempo-result-1', 'profile-1');
-      final remainingProfileOneResults =
-          await dao.getTempoSessionResults('profile-1');
-      expect(remainingProfileOneResults, hasLength(1));
-      expect(remainingProfileOneResults.single.id, 'usrpt-result-1');
+      expect(await dao.getTempoSessionResults('profile-1'), isEmpty);
       expect(await dao.getTempoSessionResults('profile-2'), hasLength(1));
     });
 

--- a/test/features/tempo/tempo_calculator_test.dart
+++ b/test/features/tempo/tempo_calculator_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:rep_swim/features/tempo/domain/services/tempo_calculator.dart';
+import 'package:rep_swim/features/tempo/domain/services/usrpt_calculator.dart';
 
 void main() {
   group('TempoCalculator', () {
@@ -54,6 +55,47 @@ void main() {
     test('flags high breath intervals for safety acknowledgement', () {
       expect(calculator.requiresBreathSafetyWarning(4), isFalse);
       expect(calculator.requiresBreathSafetyWarning(5), isTrue);
+    });
+  });
+
+  group('UsrptRacePaceCalculator', () {
+    const calculator = UsrptRacePaceCalculator();
+
+    test('calculates race pace split targets for repetitions', () {
+      final preset = calculator.calculate(
+        eventDistanceMeters: 100,
+        eventTargetTime: const Duration(seconds: 60),
+        repetitionDistanceMeters: 25,
+        restDuration: const Duration(seconds: 20),
+        failLimit: 3,
+      );
+
+      expect(preset.repetitionTargetTime, const Duration(seconds: 15));
+      expect(preset.restDuration, const Duration(seconds: 20));
+      expect(preset.repetitionsPerRace, 4);
+    });
+
+    test('rejects impossible race pace inputs', () {
+      expect(
+        () => calculator.calculate(
+          eventDistanceMeters: 100,
+          eventTargetTime: Duration.zero,
+          repetitionDistanceMeters: 25,
+          restDuration: const Duration(seconds: 20),
+          failLimit: 3,
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => calculator.calculate(
+          eventDistanceMeters: 50,
+          eventTargetTime: const Duration(seconds: 30),
+          repetitionDistanceMeters: 100,
+          restDuration: const Duration(seconds: 20),
+          failLimit: 3,
+        ),
+        throwsArgumentError,
+      );
     });
   });
 }

--- a/test/features/tempo/tempo_template_providers_test.dart
+++ b/test/features/tempo/tempo_template_providers_test.dart
@@ -6,6 +6,7 @@ import 'package:rep_swim/database/daos/training_template_dao.dart';
 import 'package:rep_swim/features/tempo/domain/entities/tempo_mode.dart';
 import 'package:rep_swim/features/tempo/domain/entities/tempo_session_result.dart';
 import 'package:rep_swim/features/tempo/domain/entities/tempo_template.dart';
+import 'package:rep_swim/features/tempo/domain/services/usrpt_calculator.dart';
 import 'package:rep_swim/features/tempo/presentation/providers/tempo_template_providers.dart';
 import 'package:rep_swim/features/tempo/presentation/providers/tempo_trainer_provider.dart';
 
@@ -191,6 +192,65 @@ void main() {
       expect(saved.notes, 'Held rhythm');
       expect(saved.actualSplits, hasLength(2));
       expect(saved.strokeCounts, [18, 19]);
+      verify(() => dao.insertTempoSessionResult(any())).called(1);
+      verify(
+        () => queue.enqueue(
+          profileId: 'profile-1',
+          entityType: 'tempo_session_result',
+          entityId: saved.id,
+          operation: SyncOperation.create,
+          payload: any(named: 'payload'),
+        ),
+      ).called(1);
+    });
+
+    test('saves USRPT result with pass fail outcomes and sync payload',
+        () async {
+      final dao = _MockTrainingTemplateDao();
+      final queue = _MockSyncQueueDao();
+      when(() => dao.getTempoSessionResults(any()))
+          .thenAnswer((_) async => [_tempoResult()]);
+      when(() => dao.insertTempoSessionResult(any())).thenAnswer((_) async {});
+      when(
+        () => queue.enqueue(
+          profileId: any(named: 'profileId'),
+          entityType: any(named: 'entityType'),
+          entityId: any(named: 'entityId'),
+          operation: any(named: 'operation'),
+          payload: any(named: 'payload'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final notifier = TempoSessionResultsNotifier(
+        dao,
+        'profile-1',
+        syncQueueDao: queue,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final preset = const UsrptRacePaceCalculator().calculate(
+        eventDistanceMeters: 100,
+        eventTargetTime: const Duration(seconds: 60),
+        repetitionDistanceMeters: 25,
+        restDuration: const Duration(seconds: 20),
+        failLimit: 2,
+      );
+      final saved = await notifier.saveUsrptResult(
+        preset: preset,
+        outcomes: const [
+          UsrptRepOutcome(index: 1, passed: true),
+          UsrptRepOutcome(index: 2, passed: false),
+        ],
+        notes: 'Faded late',
+      );
+
+      expect(saved.mode, TempoMode.lapPace);
+      expect(saved.targetDistanceMeters, 25);
+      expect(saved.targetTime, const Duration(seconds: 15));
+      expect(saved.strokeCounts, [1, 0]);
+      expect(saved.notes, contains('outcomes 1:P,2:F'));
+      expect(saved.notes, contains('Faded late'));
+      expect(saved.metadata['type'], 'usrpt');
       verify(() => dao.insertTempoSessionResult(any())).called(1);
       verify(
         () => queue.enqueue(

--- a/test/features/tempo/tempo_template_providers_test.dart
+++ b/test/features/tempo/tempo_template_providers_test.dart
@@ -356,5 +356,3 @@ void main() {
       verify(() => dao.getTempoSessionResults('profile-1'))
           .called(greaterThanOrEqualTo(2));
     });
-  });
-}

--- a/test/features/tempo/tempo_trainer_screen_test.dart
+++ b/test/features/tempo/tempo_trainer_screen_test.dart
@@ -133,7 +133,7 @@ void main() {
       expect(find.text('Vibration'), findsOneWidget);
       expect(find.text('Visual flash'), findsOneWidget);
 
-      await tester.ensureVisible(find.widgetWithText(FilledButton, 'Start'));
+      await _scrollTo(tester, find.widgetWithText(FilledButton, 'Start'));
       await tester.pumpAndSettle();
       await tester.tap(find.widgetWithText(FilledButton, 'Start'));
       await tester.pump();
@@ -159,13 +159,9 @@ void main() {
       await tester.pump();
 
       expect(find.text('Breath safety acknowledged'), findsOneWidget);
-      final startButton = tester.widget<FilledButton>(
-        find.widgetWithText(FilledButton, 'Start'),
-      );
-      expect(startButton.onPressed, isNull);
-
       await tester.tap(find.byType(CheckboxListTile));
       await tester.pump();
+      await _scrollTo(tester, find.widgetWithText(FilledButton, 'Start'));
       final enabledStart = tester.widget<FilledButton>(
         find.widgetWithText(FilledButton, 'Start'),
       );
@@ -202,6 +198,54 @@ void main() {
 
       verify(() => harness.dao.insertTempoTemplate(any())).called(1);
       expect(find.text('Saved Threshold tempo.'), findsOneWidget);
+    });
+
+    testWidgets('logs and saves a USRPT race pace result', (tester) async {
+      final harness = await _pumpTempoTrainer(tester);
+
+      await _scrollTo(tester, find.widgetWithText(TextField, 'Fail rule'));
+      await tester.enterText(find.widgetWithText(TextField, 'Fail rule'), '2');
+      await tester.tap(find.widgetWithText(OutlinedButton, 'Apply USRPT'));
+      await tester.pump();
+
+      expect(find.text('25m 00:15.00'), findsOneWidget);
+      expect(find.text('Applied USRPT race pace.'), findsOneWidget);
+
+      await tester.pump(const Duration(seconds: 4));
+      await tester.tap(find.widgetWithText(FilledButton, 'Pass Rep'));
+      await tester.pump();
+      expect(find.text('1P'), findsOneWidget);
+      expect(find.textContaining('Rest 0:20'), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(OutlinedButton, 'Rest -5s'));
+      await tester.pump();
+      expect(find.textContaining('Rest 0:15'), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Fail Rep'));
+      await tester.pump();
+      await tester.tap(find.widgetWithText(FilledButton, 'Fail Rep'));
+      await tester.pump();
+
+      expect(find.text('2F'), findsOneWidget);
+      expect(find.text('3F'), findsOneWidget);
+      expect(find.text('Fail rule reached after 2 fails.'), findsOneWidget);
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'USRPT notes'),
+        'Held first repeat',
+      );
+      await tester.tap(find.widgetWithText(FilledButton, 'Save USRPT'));
+      await tester.pump();
+
+      final captured = verify(
+        () => harness.dao.insertTempoSessionResult(captureAny()),
+      ).captured.single as TempoSessionResult;
+      expect(captured.mode, TempoMode.lapPace);
+      expect(captured.targetDistanceMeters, 25);
+      expect(captured.targetTime, const Duration(seconds: 15));
+      expect(captured.strokeCounts, [1, 0, 0]);
+      expect(captured.notes, contains('outcomes 1:P,2:F,3:F'));
+      expect(captured.notes, contains('Held first repeat'));
     });
 
     testWidgets('saves a tempo result with actual splits', (tester) async {

--- a/test/features/tempo/tempo_trainer_screen_test.dart
+++ b/test/features/tempo/tempo_trainer_screen_test.dart
@@ -160,6 +160,12 @@ void main() {
       await tester.pump();
 
       expect(find.text('Breath safety acknowledged'), findsOneWidget);
+      await _scrollTo(tester, find.widgetWithText(FilledButton, 'Start'));
+      final startButton = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Start'),
+      );
+      expect(startButton.onPressed, isNull);
+
       await tester.tap(find.byType(CheckboxListTile));
       await tester.pump();
       await _scrollTo(tester, find.widgetWithText(FilledButton, 'Start'));

--- a/test/features/tempo/usrpt_session_provider_test.dart
+++ b/test/features/tempo/usrpt_session_provider_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/tempo/presentation/providers/usrpt_session_provider.dart';
+
+void main() {
+  group('UsrptSessionNotifier', () {
+    test('tracks pass and fail outcomes and stops at fail rule', () {
+      final notifier = UsrptSessionNotifier();
+
+      notifier.configure(
+        eventDistanceMeters: 100,
+        eventTargetTime: const Duration(seconds: 60),
+        repetitionDistanceMeters: 25,
+        restDuration: const Duration(seconds: 20),
+        failLimit: 2,
+      );
+
+      notifier.logPass();
+      notifier.tickRest(const Duration(seconds: 5));
+      notifier.logFail();
+      notifier.logFail();
+      notifier.logPass();
+
+      expect(notifier.state.outcomes.map((outcome) => outcome.label), [
+        'P',
+        'F',
+        'F',
+      ]);
+      expect(notifier.state.passCount, 1);
+      expect(notifier.state.failCount, 2);
+      expect(notifier.state.failRuleReached, isTrue);
+      expect(notifier.state.restRemaining, Duration.zero);
+      expect(notifier.state.lastStatus, 'Fail rule reached after 2 fails.');
+    });
+
+    test('resets outcomes without changing configured preset', () {
+      final notifier = UsrptSessionNotifier();
+
+      notifier.configure(
+        eventDistanceMeters: 200,
+        eventTargetTime: const Duration(seconds: 130),
+        repetitionDistanceMeters: 50,
+        restDuration: const Duration(seconds: 25),
+        failLimit: 3,
+      );
+      notifier.logPass();
+      notifier.resetOutcomes();
+
+      expect(notifier.state.outcomes, isEmpty);
+      expect(notifier.state.preset.repetitionTargetTime,
+          const Duration(milliseconds: 32500));
+      expect(notifier.state.failRuleReached, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add USRPT race pace calculation for event target time, repeat distance, rest, and fail rule
- add Tempo Trainer UI for pass/fail rep logging, rest countdown, fail-rule stopping, and live lap-pace cue setup
- save USRPT outcomes through offline tempo session results with sync metadata

## Tests
- dart format lib test
- flutter test test/features/tempo test/database/dao_integration_test.dart test/core/sync/sync_payloads_test.dart
- flutter analyze
- flutter test

Closes #18