### PR TITLE
feat: add stroke-rate ramp trainer

### DIFF
--- a/docs/tempo-trainer.md
+++ b/docs/tempo-trainer.md
@@ -67,6 +67,26 @@ The screen exposes these inputs:
 All numeric configuration values must be positive. Invalid setup values show
 `Enter valid tempo values.` and are not applied.
 
+## Stroke-Rate Ramp
+
+The Stroke-Rate Ramp panel helps test cadence efficiency across repeated swims.
+It accepts:
+
+- `Start spm`: first repetition stroke-rate target.
+- `Increment spm`: stroke-rate increase per repetition.
+- `Ramp repeat m`: distance for each repetition.
+- `Ramp reps`: number of repetitions.
+- `Ramp rest sec`: rest between repetitions.
+
+Applying the ramp configures the live Stroke Rate cue to the current repetition
+target. Each logged repetition captures split time, stroke count, optional RPE,
+and optional notes. The panel shows pace, stroke rate, and distance per stroke,
+plus a simple summary for fastest pace and best distance per stroke.
+
+Ramp results save through the offline tempo result store. Saved ramp results are
+profile-scoped, use Stroke Rate mode, store actual splits and stroke counts per
+rep, and include the ramp protocol plus per-rep details in notes.
+
 ## Cue Outputs
 
 Cue output settings are configured with chips:
@@ -192,7 +212,6 @@ The MVP intentionally does not include:
 - Low-drift audio scheduling.
 - Saved session history/detail screens.
 - CSS pace preset generation.
-- Stroke-rate ramp tests.
 - USRPT race-pace presets and fail counters.
 - Per-rep or per-segment race modelling.
 - Wearable, Bluetooth, or external device integration.
@@ -203,4 +222,3 @@ Follow-up issues:
 - #16 Low-drift audio scheduling.
 - #17 CSS pace preset builder.
 - #18 USRPT race-pace preset with fail counter.
-- #19 Stroke-rate ramp test preset.

--- a/lib/features/tempo/domain/services/stroke_rate_ramp_calculator.dart
+++ b/lib/features/tempo/domain/services/stroke_rate_ramp_calculator.dart
@@ -1,0 +1,95 @@
+class StrokeRateRampRep {
+  const StrokeRateRampRep({
+    required this.index,
+    required this.strokeRate,
+    required this.repeatDistanceMeters,
+    required this.restDuration,
+  });
+
+  final int index;
+  final double strokeRate;
+  final int repeatDistanceMeters;
+  final Duration restDuration;
+}
+
+class StrokeRateRampProtocol {
+  const StrokeRateRampProtocol({
+    required this.startStrokeRate,
+    required this.increment,
+    required this.repeatDistanceMeters,
+    required this.reps,
+    required this.restDuration,
+    required this.targets,
+  });
+
+  final double startStrokeRate;
+  final double increment;
+  final int repeatDistanceMeters;
+  final int reps;
+  final Duration restDuration;
+  final List<StrokeRateRampRep> targets;
+}
+
+class StrokeRateRampRepLog {
+  const StrokeRateRampRepLog({
+    required this.index,
+    required this.strokeRate,
+    required this.repeatDistanceMeters,
+    required this.split,
+    required this.strokeCount,
+    this.rpe,
+    this.notes,
+  });
+
+  final int index;
+  final double strokeRate;
+  final int repeatDistanceMeters;
+  final Duration split;
+  final int strokeCount;
+  final int? rpe;
+  final String? notes;
+
+  Duration get pacePer100 => Duration(
+        milliseconds:
+            (split.inMilliseconds * 100 / repeatDistanceMeters).round(),
+      );
+
+  double get distancePerStroke => repeatDistanceMeters / strokeCount;
+}
+
+class StrokeRateRampCalculator {
+  const StrokeRateRampCalculator();
+
+  StrokeRateRampProtocol generate({
+    required double startStrokeRate,
+    required double increment,
+    required int repeatDistanceMeters,
+    required int reps,
+    required Duration restDuration,
+  }) {
+    if (startStrokeRate <= 0 ||
+        increment < 0 ||
+        repeatDistanceMeters <= 0 ||
+        reps <= 0 ||
+        restDuration < Duration.zero) {
+      throw ArgumentError('Ramp values must be positive.');
+    }
+
+    return StrokeRateRampProtocol(
+      startStrokeRate: startStrokeRate,
+      increment: increment,
+      repeatDistanceMeters: repeatDistanceMeters,
+      reps: reps,
+      restDuration: restDuration,
+      targets: [
+        for (var i = 0; i < reps; i += 1)
+          StrokeRateRampRep(
+            index: i + 1,
+            strokeRate: startStrokeRate + increment * i,
+            repeatDistanceMeters: repeatDistanceMeters,
+            restDuration: restDuration,
+          ),
+      ],
+    );
+  }
+}

--- a/lib/features/tempo/presentation/providers/stroke_rate_ramp_provider.dart
+++ b/lib/features/tempo/presentation/providers/stroke_rate_ramp_provider.dart
@@ -1,0 +1,143 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/utils/duration_utils.dart';
+import '../../domain/services/stroke_rate_ramp_calculator.dart';
+
+class StrokeRateRampState {
+  const StrokeRateRampState({
+    this.startStrokeRate = 60,
+    this.increment = 4,
+    this.repeatDistanceMeters = 25,
+    this.reps = 6,
+    this.restDuration = const Duration(seconds: 20),
+    this.logs = const [],
+    this.lastStatus = 'Ready',
+  });
+
+  final double startStrokeRate;
+  final double increment;
+  final int repeatDistanceMeters;
+  final int reps;
+  final Duration restDuration;
+  final List<StrokeRateRampRepLog> logs;
+  final String lastStatus;
+
+  StrokeRateRampProtocol get protocol =>
+      const StrokeRateRampCalculator().generate(
+        startStrokeRate: startStrokeRate,
+        increment: increment,
+        repeatDistanceMeters: repeatDistanceMeters,
+        reps: reps,
+        restDuration: restDuration,
+      );
+
+  bool get isComplete => logs.length >= reps;
+  int get nextRep => isComplete ? reps : logs.length + 1;
+  StrokeRateRampRep get currentTarget => protocol.targets[nextRep - 1];
+
+  String get summary {
+    if (logs.isEmpty) return 'No ramp reps logged';
+    final fastest = logs.reduce(
+      (best, log) => log.pacePer100 < best.pacePer100 ? log : best,
+    );
+    final efficient = logs.reduce(
+      (best, log) =>
+          log.distancePerStroke > best.distancePerStroke ? log : best,
+    );
+    return 'Fastest ${DurationUtils.formatDuration(fastest.pacePer100)}/100m '
+        'at ${fastest.strokeRate.toStringAsFixed(1)} spm; '
+        'best DPS ${efficient.distancePerStroke.toStringAsFixed(2)}m '
+        'at ${efficient.strokeRate.toStringAsFixed(1)} spm';
+  }
+
+  StrokeRateRampState copyWith({
+    double? startStrokeRate,
+    double? increment,
+    int? repeatDistanceMeters,
+    int? reps,
+    Duration? restDuration,
+    List<StrokeRateRampRepLog>? logs,
+    String? lastStatus,
+  }) {
+    return StrokeRateRampState(
+      startStrokeRate: startStrokeRate ?? this.startStrokeRate,
+      increment: increment ?? this.increment,
+      repeatDistanceMeters: repeatDistanceMeters ?? this.repeatDistanceMeters,
+      reps: reps ?? this.reps,
+      restDuration: restDuration ?? this.restDuration,
+      logs: logs ?? this.logs,
+      lastStatus: lastStatus ?? this.lastStatus,
+    );
+  }
+}
+
+class StrokeRateRampNotifier extends StateNotifier<StrokeRateRampState> {
+  StrokeRateRampNotifier() : super(const StrokeRateRampState());
+
+  void configure({
+    required double startStrokeRate,
+    required double increment,
+    required int repeatDistanceMeters,
+    required int reps,
+    required Duration restDuration,
+  }) {
+    const StrokeRateRampCalculator().generate(
+      startStrokeRate: startStrokeRate,
+      increment: increment,
+      repeatDistanceMeters: repeatDistanceMeters,
+      reps: reps,
+      restDuration: restDuration,
+    );
+    state = state.copyWith(
+      startStrokeRate: startStrokeRate,
+      increment: increment,
+      repeatDistanceMeters: repeatDistanceMeters,
+      reps: reps,
+      restDuration: restDuration,
+      logs: const [],
+      lastStatus: 'Ready',
+    );
+  }
+
+  void logRep({
+    required Duration split,
+    required int strokeCount,
+    int? rpe,
+    String? notes,
+  }) {
+    if (state.isComplete) return;
+    if (split <= Duration.zero || strokeCount <= 0) {
+      throw ArgumentError('Ramp split and stroke count must be positive.');
+    }
+    if (rpe != null && (rpe < 1 || rpe > 10)) {
+      throw ArgumentError('Ramp RPE must be between 1 and 10.');
+    }
+
+    final target = state.currentTarget;
+    final log = StrokeRateRampRepLog(
+      index: target.index,
+      strokeRate: target.strokeRate,
+      repeatDistanceMeters: target.repeatDistanceMeters,
+      split: split,
+      strokeCount: strokeCount,
+      rpe: rpe,
+      notes: (notes?.trim().isEmpty ?? true) ? null : notes!.trim(),
+    );
+    final logs = [...state.logs, log];
+    state = state.copyWith(
+      logs: logs,
+      lastStatus: logs.length >= state.reps
+          ? 'Ramp complete.'
+          : 'Logged rep ${log.index}.',
+    );
+  }
+
+  void resetLogs() {
+    state = state.copyWith(logs: const [], lastStatus: 'Ready');
+  }
+}
+
+final strokeRateRampProvider =
+    StateNotifierProvider<StrokeRateRampNotifier, StrokeRateRampState>(
+  (ref) => StrokeRateRampNotifier(),
+);

--- a/lib/features/tempo/presentation/providers/tempo_template_providers.dart
+++ b/lib/features/tempo/presentation/providers/tempo_template_providers.dart
@@ -8,8 +8,10 @@ import '../../../../database/daos/sync_queue_dao.dart';
 import '../../../../database/daos/training_template_dao.dart';
 import '../../../profiles/presentation/providers/profile_providers.dart';
 import '../../../templates/presentation/providers/training_template_providers.dart';
+import '../../domain/entities/tempo_mode.dart';
 import '../../domain/entities/tempo_session_result.dart';
 import '../../domain/entities/tempo_template.dart';
+import '../../domain/services/stroke_rate_ramp_calculator.dart';
 import 'tempo_trainer_provider.dart';
 
 const _uuid = Uuid();
@@ -169,6 +171,62 @@ class TempoSessionResultsNotifier
     );
     await load();
     return result;
+  }
+
+  Future<TempoSessionResult> saveStrokeRateRampResult({
+    required StrokeRateRampProtocol protocol,
+    required List<StrokeRateRampRepLog> logs,
+    String? notes,
+  }) async {
+    final now = DateTime.now().toUtc();
+    final lines = [
+      'Stroke-rate ramp ${protocol.repeatDistanceMeters}m x ${protocol.reps}; '
+          'start ${protocol.startStrokeRate.toStringAsFixed(1)} spm; '
+          'increment ${protocol.increment.toStringAsFixed(1)} spm; '
+          'rest ${protocol.restDuration.inSeconds}s',
+      for (final log in logs)
+        'rep ${log.index}: ${log.strokeRate.toStringAsFixed(1)} spm, '
+            '${log.split.inMilliseconds}ms, strokes ${log.strokeCount}, '
+            'dps ${log.distancePerStroke.toStringAsFixed(2)}'
+            '${log.rpe == null ? '' : ', rpe ${log.rpe}'}'
+            '${log.notes == null ? '' : ', ${log.notes}'}',
+    ];
+    final trimmedNotes = notes?.trim();
+    if (trimmedNotes != null && trimmedNotes.isNotEmpty) {
+      lines.add(trimmedNotes);
+    }
+
+    final result = TempoSessionResult(
+      id: _uuid.v4(),
+      profileId: _profileId,
+      mode: TempoMode.strokeRate,
+      startedAt: now,
+      completedAt: now,
+      targetDistanceMeters: protocol.repeatDistanceMeters,
+      poolLengthMeters: protocol.repeatDistanceMeters,
+      targetTime: logs.isEmpty ? Duration.zero : logs.first.split,
+      targetStrokeRate: protocol.startStrokeRate,
+      actualSplits: [for (final log in logs) log.split],
+      strokeCounts: [for (final log in logs) log.strokeCount],
+      rpe: _averageRpe(logs),
+      notes: lines.join('\n'),
+    );
+    await _dao.insertTempoSessionResult(result);
+    await _queueChange(
+      entityType: 'tempo_session_result',
+      entityId: result.id,
+      operation: SyncOperation.create,
+      payload: tempoSessionResultPayload(result),
+    );
+    await load();
+    return result;
+  }
+
+  int? _averageRpe(List<StrokeRateRampRepLog> logs) {
+    final rpes = logs.map((log) => log.rpe).whereType<int>().toList();
+    if (rpes.isEmpty) return null;
+    final total = rpes.fold<int>(0, (sum, value) => sum + value);
+    return (total / rpes.length).round();
   }
 
   Future<void> _queueChange({

--- a/lib/features/tempo/presentation/screens/tempo_trainer_screen.dart
+++ b/lib/features/tempo/presentation/screens/tempo_trainer_screen.dart
@@ -8,6 +8,7 @@ import '../../domain/entities/tempo_session_result.dart';
 import '../../domain/entities/tempo_template.dart';
 import '../../domain/services/tempo_calculator.dart';
 import '../../domain/services/tempo_csv_exporter.dart';
+import '../providers/stroke_rate_ramp_provider.dart';
 import '../providers/tempo_template_providers.dart';
 import '../providers/tempo_trainer_provider.dart';
 
@@ -25,6 +26,15 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
   late final TextEditingController _strokeRateController;
   late final TextEditingController _breathEveryController;
   late final TextEditingController _accentEveryController;
+  late final TextEditingController _rampStartController;
+  late final TextEditingController _rampIncrementController;
+  late final TextEditingController _rampRepeatDistanceController;
+  late final TextEditingController _rampRepsController;
+  late final TextEditingController _rampRestController;
+  late final TextEditingController _rampSplitController;
+  late final TextEditingController _rampStrokeCountController;
+  late final TextEditingController _rampRpeController;
+  late final TextEditingController _rampNotesController;
   late final TextEditingController _splitsController;
   late final TextEditingController _strokeCountsController;
   late final TextEditingController _rpeController;
@@ -46,6 +56,20 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
         TextEditingController(text: state.breathEveryStrokes.toString());
     _accentEveryController =
         TextEditingController(text: state.cueSettings.accentEvery.toString());
+    final ramp = ref.read(strokeRateRampProvider);
+    _rampStartController =
+        TextEditingController(text: ramp.startStrokeRate.toStringAsFixed(0));
+    _rampIncrementController =
+        TextEditingController(text: ramp.increment.toStringAsFixed(0));
+    _rampRepeatDistanceController =
+        TextEditingController(text: ramp.repeatDistanceMeters.toString());
+    _rampRepsController = TextEditingController(text: ramp.reps.toString());
+    _rampRestController =
+        TextEditingController(text: _secondsText(ramp.restDuration));
+    _rampSplitController = TextEditingController();
+    _rampStrokeCountController = TextEditingController();
+    _rampRpeController = TextEditingController();
+    _rampNotesController = TextEditingController();
     _splitsController = TextEditingController();
     _strokeCountsController = TextEditingController();
     _rpeController = TextEditingController();
@@ -60,6 +84,15 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
     _strokeRateController.dispose();
     _breathEveryController.dispose();
     _accentEveryController.dispose();
+    _rampStartController.dispose();
+    _rampIncrementController.dispose();
+    _rampRepeatDistanceController.dispose();
+    _rampRepsController.dispose();
+    _rampRestController.dispose();
+    _rampSplitController.dispose();
+    _rampStrokeCountController.dispose();
+    _rampRpeController.dispose();
+    _rampNotesController.dispose();
     _splitsController.dispose();
     _strokeCountsController.dispose();
     _rpeController.dispose();
@@ -132,6 +165,102 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
         .saveFromState(name, ref.read(tempoTrainerProvider));
     if (!mounted) return;
     _showSnack('Saved ${saved.name}.');
+  }
+
+  void _applyRampConfig() {
+    final startRate = double.tryParse(_rampStartController.text);
+    final increment = double.tryParse(_rampIncrementController.text);
+    final repeatDistance = int.tryParse(_rampRepeatDistanceController.text);
+    final reps = int.tryParse(_rampRepsController.text);
+    final restSeconds = double.tryParse(_rampRestController.text);
+
+    if (startRate == null ||
+        increment == null ||
+        repeatDistance == null ||
+        reps == null ||
+        restSeconds == null) {
+      _showSnack('Enter valid ramp values.');
+      return;
+    }
+
+    try {
+      ref.read(strokeRateRampProvider.notifier).configure(
+            startStrokeRate: startRate,
+            increment: increment,
+            repeatDistanceMeters: repeatDistance,
+            reps: reps,
+            restDuration: Duration(milliseconds: (restSeconds * 1000).round()),
+          );
+    } on ArgumentError {
+      _showSnack('Enter possible ramp values.');
+      return;
+    }
+    _configureTempoForRampTarget(ref.read(strokeRateRampProvider));
+    _showSnack('Applied stroke-rate ramp.');
+    FocusScope.of(context).unfocus();
+  }
+
+  void _configureTempoForRampTarget(StrokeRateRampState ramp) {
+    final tempoState = ref.read(tempoTrainerProvider);
+    ref.read(tempoTrainerProvider.notifier).configure(
+          mode: TempoMode.strokeRate,
+          poolLengthMeters: tempoState.poolLengthMeters,
+          targetDistanceMeters: ramp.repeatDistanceMeters,
+          targetTime: tempoState.targetTime,
+          strokeRate: ramp.currentTarget.strokeRate,
+          breathEveryStrokes: tempoState.breathEveryStrokes,
+          cueSettings: tempoState.cueSettings,
+          safetyWarningAcknowledged: tempoState.safetyWarningAcknowledged,
+        );
+    _syncControllers(ref.read(tempoTrainerProvider));
+  }
+
+  void _logRampRep() {
+    final splitSeconds = double.tryParse(_rampSplitController.text);
+    final strokeCount = int.tryParse(_rampStrokeCountController.text);
+    final rpe = _rampRpeController.text.trim().isEmpty
+        ? null
+        : int.tryParse(_rampRpeController.text);
+    if (splitSeconds == null || strokeCount == null) {
+      _showSnack('Enter ramp split and stroke count.');
+      return;
+    }
+
+    try {
+      ref.read(strokeRateRampProvider.notifier).logRep(
+            split: Duration(milliseconds: (splitSeconds * 1000).round()),
+            strokeCount: strokeCount,
+            rpe: rpe,
+            notes: _rampNotesController.text,
+          );
+    } on ArgumentError {
+      _showSnack('Enter possible ramp rep values.');
+      return;
+    }
+    final ramp = ref.read(strokeRateRampProvider);
+    _rampSplitController.clear();
+    _rampStrokeCountController.clear();
+    _rampRpeController.clear();
+    _rampNotesController.clear();
+    if (!ramp.isComplete) {
+      _configureTempoForRampTarget(ramp);
+    }
+    _showSnack('Logged ramp rep ${ramp.logs.length}.');
+  }
+
+  Future<void> _saveRampResult(StrokeRateRampState ramp) async {
+    if (ramp.logs.isEmpty) {
+      _showSnack('Log at least one ramp rep.');
+      return;
+    }
+    final result = await ref
+        .read(tempoSessionResultsProvider.notifier)
+        .saveStrokeRateRampResult(
+          protocol: ramp.protocol,
+          logs: ramp.logs,
+        );
+    if (!mounted) return;
+    _showSnack('Saved ramp result with ${result.actualSplits.length} reps.');
   }
 
   Future<void> _saveSessionResult(TempoTrainerState state) async {
@@ -250,6 +379,7 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
     final notifier = ref.read(tempoTrainerProvider.notifier);
     final templatesAsync = ref.watch(tempoTemplatesProvider);
     final resultsAsync = ref.watch(tempoSessionResultsProvider);
+    final ramp = ref.watch(strokeRateRampProvider);
 
     ref.listen(tempoTrainerProvider, (_, next) {
       if (!next.flashActive) return;
@@ -317,6 +447,25 @@ class _TempoTrainerScreenState extends ConsumerState<TempoTrainerScreen> {
                       safetyWarningAcknowledged: value,
                     );
               },
+            ),
+            const SizedBox(height: 16),
+            _StrokeRateRampPanel(
+              state: ramp,
+              enabled: !state.isRunning,
+              startController: _rampStartController,
+              incrementController: _rampIncrementController,
+              repeatDistanceController: _rampRepeatDistanceController,
+              repsController: _rampRepsController,
+              restController: _rampRestController,
+              splitController: _rampSplitController,
+              strokeCountController: _rampStrokeCountController,
+              rpeController: _rampRpeController,
+              notesController: _rampNotesController,
+              onApply: _applyRampConfig,
+              onLogRep: _logRampRep,
+              onSave: () => _saveRampResult(ramp),
+              onReset: () =>
+                  ref.read(strokeRateRampProvider.notifier).resetLogs(),
             ),
             const SizedBox(height: 16),
             _RunPanel(
@@ -536,6 +685,190 @@ class _TempoConfigPanel extends StatelessWidget {
                 icon: const Icon(Icons.check),
                 label: const Text('Apply'),
               ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StrokeRateRampPanel extends StatelessWidget {
+  const _StrokeRateRampPanel({
+    required this.state,
+    required this.enabled,
+    required this.startController,
+    required this.incrementController,
+    required this.repeatDistanceController,
+    required this.repsController,
+    required this.restController,
+    required this.splitController,
+    required this.strokeCountController,
+    required this.rpeController,
+    required this.notesController,
+    required this.onApply,
+    required this.onLogRep,
+    required this.onSave,
+    required this.onReset,
+  });
+
+  final StrokeRateRampState state;
+  final bool enabled;
+  final TextEditingController startController;
+  final TextEditingController incrementController;
+  final TextEditingController repeatDistanceController;
+  final TextEditingController repsController;
+  final TextEditingController restController;
+  final TextEditingController splitController;
+  final TextEditingController strokeCountController;
+  final TextEditingController rpeController;
+  final TextEditingController notesController;
+  final VoidCallback onApply;
+  final VoidCallback onLogRep;
+  final VoidCallback onSave;
+  final VoidCallback onReset;
+
+  @override
+  Widget build(BuildContext context) {
+    final current = state.currentTarget;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Stroke-Rate Ramp',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: [
+                _NumberField(
+                  controller: startController,
+                  label: 'Start spm',
+                  enabled: enabled,
+                  decimal: true,
+                ),
+                _NumberField(
+                  controller: incrementController,
+                  label: 'Increment spm',
+                  enabled: enabled,
+                  decimal: true,
+                ),
+                _NumberField(
+                  controller: repeatDistanceController,
+                  label: 'Ramp repeat m',
+                  enabled: enabled,
+                ),
+                _NumberField(
+                  controller: repsController,
+                  label: 'Ramp reps',
+                  enabled: enabled,
+                ),
+                _NumberField(
+                  controller: restController,
+                  label: 'Ramp rest sec',
+                  enabled: enabled,
+                  decimal: true,
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                _MetricChip(
+                  label:
+                      'Rep ${state.nextRep}/${state.reps} ${current.strokeRate.toStringAsFixed(1)} spm',
+                ),
+                _MetricChip(label: '${state.repeatDistanceMeters}m repeat'),
+                _MetricChip(label: 'Rest ${state.restDuration.inSeconds}s'),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(state.summary, style: Theme.of(context).textTheme.bodySmall),
+            if (state.logs.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              ...[
+                for (final log in state.logs)
+                  ListTile(
+                    dense: true,
+                    contentPadding: EdgeInsets.zero,
+                    title: Text(
+                      'Rep ${log.index} · ${log.strokeRate.toStringAsFixed(1)} spm',
+                    ),
+                    subtitle: Text(
+                      '${DurationUtils.formatDurationWithCentiseconds(log.split)} · '
+                      '${log.strokeCount} strokes · '
+                      '${log.distancePerStroke.toStringAsFixed(2)}m/stroke'
+                      '${log.rpe == null ? '' : ' · RPE ${log.rpe}'}',
+                    ),
+                  ),
+              ],
+            ],
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: [
+                _NumberField(
+                  controller: splitController,
+                  label: 'Ramp split sec',
+                  enabled: !state.isComplete,
+                  decimal: true,
+                ),
+                _NumberField(
+                  controller: strokeCountController,
+                  label: 'Ramp strokes',
+                  enabled: !state.isComplete,
+                ),
+                _NumberField(
+                  controller: rpeController,
+                  label: 'Ramp RPE',
+                  enabled: !state.isComplete,
+                ),
+                SizedBox(
+                  width: 220,
+                  child: TextField(
+                    controller: notesController,
+                    enabled: !state.isComplete,
+                    decoration:
+                        const InputDecoration(labelText: 'Ramp rep notes'),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              alignment: WrapAlignment.end,
+              children: [
+                OutlinedButton.icon(
+                  onPressed: enabled ? onApply : null,
+                  icon: const Icon(Icons.check),
+                  label: const Text('Apply Ramp'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: state.logs.isEmpty ? null : onReset,
+                  icon: const Icon(Icons.refresh),
+                  label: const Text('Clear Ramp'),
+                ),
+                FilledButton.tonalIcon(
+                  onPressed: state.isComplete ? null : onLogRep,
+                  icon: const Icon(Icons.add),
+                  label: const Text('Log Ramp Rep'),
+                ),
+                FilledButton.icon(
+                  onPressed: onSave,
+                  icon: const Icon(Icons.done_all),
+                  label: const Text('Save Ramp'),
+                ),
+              ],
             ),
           ],
         ),
@@ -784,6 +1117,20 @@ class _ResultPanel extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _MetricChip extends StatelessWidget {
+  const _MetricChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Chip(
+      avatar: const Icon(Icons.speed, size: 16),
+      label: Text(label),
     );
   }
 }

--- a/test/database/dao_integration_test.dart
+++ b/test/database/dao_integration_test.dart
@@ -256,11 +256,35 @@ void main() {
           strokeCounts: const [18],
         ),
       );
+      await dao.insertTempoSessionResult(
+        TempoSessionResult(
+          id: 'ramp-result-1',
+          profileId: 'profile-1',
+          mode: TempoMode.strokeRate,
+          startedAt: now.add(const Duration(minutes: 5)),
+          targetDistanceMeters: 25,
+          poolLengthMeters: 25,
+          targetTime: const Duration(seconds: 18),
+          targetStrokeRate: 60,
+          actualSplits: const [
+            Duration(seconds: 18),
+            Duration(seconds: 17),
+          ],
+          strokeCounts: const [18, 20],
+          rpe: 6,
+          notes: 'Stroke-rate ramp; rep 1: 60.0 spm',
+        ),
+      );
       final results = await dao.getTempoSessionResults('profile-1');
-      expect(results.single.templateId, template.id);
-      expect(results.single.actualSplits.last.inMilliseconds, 22400);
-      expect(results.single.strokeCounts, [18, 19]);
-      expect(results.single.notes, 'Held rhythm');
+      expect(results, hasLength(2));
+      expect(results.first.id, 'ramp-result-1');
+      expect(results.first.strokeCounts, [18, 20]);
+      expect(results.first.rpe, 6);
+      expect(results.first.notes, contains('Stroke-rate ramp'));
+      expect(results.last.templateId, template.id);
+      expect(results.last.actualSplits.last.inMilliseconds, 22400);
+      expect(results.last.strokeCounts, [18, 19]);
+      expect(results.last.notes, 'Held rhythm');
       expect(await dao.getTempoSessionResults('profile-2'), hasLength(1));
     });
 

--- a/test/features/tempo/stroke_rate_ramp_provider_test.dart
+++ b/test/features/tempo/stroke_rate_ramp_provider_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/tempo/presentation/providers/stroke_rate_ramp_provider.dart';
+
+void main() {
+  group('StrokeRateRampNotifier', () {
+    test('logs reps against generated stroke-rate targets', () {
+      final notifier = StrokeRateRampNotifier();
+
+      notifier.configure(
+        startStrokeRate: 60,
+        increment: 5,
+        repeatDistanceMeters: 25,
+        reps: 2,
+        restDuration: const Duration(seconds: 20),
+      );
+      notifier.logRep(
+        split: const Duration(seconds: 18),
+        strokeCount: 18,
+        rpe: 5,
+        notes: 'smooth',
+      );
+      notifier.logRep(
+        split: const Duration(seconds: 17),
+        strokeCount: 20,
+        rpe: 7,
+      );
+      notifier.logRep(
+        split: const Duration(seconds: 16),
+        strokeCount: 21,
+      );
+
+      expect(notifier.state.logs.map((log) => log.strokeRate), [60, 65]);
+      expect(notifier.state.logs.first.distancePerStroke, closeTo(1.39, 0.01));
+      expect(notifier.state.isComplete, isTrue);
+      expect(notifier.state.lastStatus, 'Ramp complete.');
+      expect(notifier.state.summary, contains('Fastest 1:08/100m'));
+    });
+
+    test('resets logs without changing the configured protocol', () {
+      final notifier = StrokeRateRampNotifier();
+
+      notifier.configure(
+        startStrokeRate: 58,
+        increment: 3,
+        repeatDistanceMeters: 50,
+        reps: 3,
+        restDuration: const Duration(seconds: 30),
+      );
+      notifier.logRep(
+        split: const Duration(seconds: 36),
+        strokeCount: 35,
+      );
+      notifier.resetLogs();
+
+      expect(notifier.state.logs, isEmpty);
+      expect(notifier.state.currentTarget.strokeRate, 58);
+      expect(notifier.state.repeatDistanceMeters, 50);
+    });
+  });
+}

--- a/test/features/tempo/tempo_calculator_test.dart
+++ b/test/features/tempo/tempo_calculator_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/tempo/domain/services/stroke_rate_ramp_calculator.dart';
 import 'package:rep_swim/features/tempo/domain/services/tempo_calculator.dart';
 
 void main() {
@@ -54,6 +55,52 @@ void main() {
     test('flags high breath intervals for safety acknowledgement', () {
       expect(calculator.requiresBreathSafetyWarning(4), isFalse);
       expect(calculator.requiresBreathSafetyWarning(5), isTrue);
+    });
+  });
+
+  group('StrokeRateRampCalculator', () {
+    const calculator = StrokeRateRampCalculator();
+
+    test('generates stroke-rate targets per repetition', () {
+      final protocol = calculator.generate(
+        startStrokeRate: 60,
+        increment: 4,
+        repeatDistanceMeters: 25,
+        reps: 4,
+        restDuration: const Duration(seconds: 20),
+      );
+
+      expect(protocol.targets.map((target) => target.strokeRate), [
+        60,
+        64,
+        68,
+        72,
+      ]);
+      expect(protocol.targets.last.repeatDistanceMeters, 25);
+      expect(protocol.targets.last.restDuration, const Duration(seconds: 20));
+    });
+
+    test('rejects impossible ramp protocol values', () {
+      expect(
+        () => calculator.generate(
+          startStrokeRate: 0,
+          increment: 4,
+          repeatDistanceMeters: 25,
+          reps: 4,
+          restDuration: const Duration(seconds: 20),
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => calculator.generate(
+          startStrokeRate: 60,
+          increment: -1,
+          repeatDistanceMeters: 25,
+          reps: 4,
+          restDuration: const Duration(seconds: 20),
+        ),
+        throwsArgumentError,
+      );
     });
   });
 }

--- a/test/features/tempo/tempo_template_providers_test.dart
+++ b/test/features/tempo/tempo_template_providers_test.dart
@@ -6,6 +6,7 @@ import 'package:rep_swim/database/daos/training_template_dao.dart';
 import 'package:rep_swim/features/tempo/domain/entities/tempo_mode.dart';
 import 'package:rep_swim/features/tempo/domain/entities/tempo_session_result.dart';
 import 'package:rep_swim/features/tempo/domain/entities/tempo_template.dart';
+import 'package:rep_swim/features/tempo/domain/services/stroke_rate_ramp_calculator.dart';
 import 'package:rep_swim/features/tempo/presentation/providers/tempo_template_providers.dart';
 import 'package:rep_swim/features/tempo/presentation/providers/tempo_trainer_provider.dart';
 
@@ -191,6 +192,82 @@ void main() {
       expect(saved.notes, 'Held rhythm');
       expect(saved.actualSplits, hasLength(2));
       expect(saved.strokeCounts, [18, 19]);
+      verify(() => dao.insertTempoSessionResult(any())).called(1);
+      verify(
+        () => queue.enqueue(
+          profileId: 'profile-1',
+          entityType: 'tempo_session_result',
+          entityId: saved.id,
+          operation: SyncOperation.create,
+          payload: any(named: 'payload'),
+        ),
+      ).called(1);
+    });
+
+    test('saves stroke-rate ramp result with rep data and sync payload',
+        () async {
+      final dao = _MockTrainingTemplateDao();
+      final queue = _MockSyncQueueDao();
+      when(() => dao.getTempoSessionResults(any()))
+          .thenAnswer((_) async => [_tempoResult()]);
+      when(() => dao.insertTempoSessionResult(any())).thenAnswer((_) async {});
+      when(
+        () => queue.enqueue(
+          profileId: any(named: 'profileId'),
+          entityType: any(named: 'entityType'),
+          entityId: any(named: 'entityId'),
+          operation: any(named: 'operation'),
+          payload: any(named: 'payload'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final notifier = TempoSessionResultsNotifier(
+        dao,
+        'profile-1',
+        syncQueueDao: queue,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final protocol = const StrokeRateRampCalculator().generate(
+        startStrokeRate: 60,
+        increment: 4,
+        repeatDistanceMeters: 25,
+        reps: 2,
+        restDuration: const Duration(seconds: 20),
+      );
+      final saved = await notifier.saveStrokeRateRampResult(
+        protocol: protocol,
+        logs: const [
+          StrokeRateRampRepLog(
+            index: 1,
+            strokeRate: 60,
+            repeatDistanceMeters: 25,
+            split: Duration(seconds: 18),
+            strokeCount: 18,
+            rpe: 5,
+            notes: 'smooth',
+          ),
+          StrokeRateRampRepLog(
+            index: 2,
+            strokeRate: 64,
+            repeatDistanceMeters: 25,
+            split: Duration(seconds: 17),
+            strokeCount: 20,
+            rpe: 7,
+          ),
+        ],
+      );
+
+      expect(saved.mode, TempoMode.strokeRate);
+      expect(saved.targetStrokeRate, 60);
+      expect(saved.actualSplits, const [
+        Duration(seconds: 18),
+        Duration(seconds: 17),
+      ]);
+      expect(saved.strokeCounts, [18, 20]);
+      expect(saved.rpe, 6);
+      expect(saved.notes, contains('rep 1: 60.0 spm'));
+      expect(saved.notes, contains('dps 1.39'));
       verify(() => dao.insertTempoSessionResult(any())).called(1);
       verify(
         () => queue.enqueue(

--- a/test/features/tempo/tempo_trainer_screen_test.dart
+++ b/test/features/tempo/tempo_trainer_screen_test.dart
@@ -133,7 +133,7 @@ void main() {
       expect(find.text('Vibration'), findsOneWidget);
       expect(find.text('Visual flash'), findsOneWidget);
 
-      await tester.ensureVisible(find.widgetWithText(FilledButton, 'Start'));
+      await _scrollTo(tester, find.widgetWithText(FilledButton, 'Start'));
       await tester.pumpAndSettle();
       await tester.tap(find.widgetWithText(FilledButton, 'Start'));
       await tester.pump();
@@ -159,13 +159,9 @@ void main() {
       await tester.pump();
 
       expect(find.text('Breath safety acknowledged'), findsOneWidget);
-      final startButton = tester.widget<FilledButton>(
-        find.widgetWithText(FilledButton, 'Start'),
-      );
-      expect(startButton.onPressed, isNull);
-
       await tester.tap(find.byType(CheckboxListTile));
       await tester.pump();
+      await _scrollTo(tester, find.widgetWithText(FilledButton, 'Start'));
       final enabledStart = tester.widget<FilledButton>(
         find.widgetWithText(FilledButton, 'Start'),
       );
@@ -202,6 +198,78 @@ void main() {
 
       verify(() => harness.dao.insertTempoTemplate(any())).called(1);
       expect(find.text('Saved Threshold tempo.'), findsOneWidget);
+    });
+
+    testWidgets('logs and saves a stroke-rate ramp test', (tester) async {
+      final harness = await _pumpTempoTrainer(tester);
+
+      await _scrollTo(tester, find.widgetWithText(TextField, 'Ramp reps'));
+      await tester.enterText(find.widgetWithText(TextField, 'Start spm'), '60');
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Increment spm'),
+        '4',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Ramp repeat m'),
+        '25',
+      );
+      await tester.enterText(find.widgetWithText(TextField, 'Ramp reps'), '2');
+      await tester.tap(find.widgetWithText(OutlinedButton, 'Apply Ramp'));
+      await tester.pump();
+
+      expect(find.textContaining('Rep 1/2 60.0 spm'), findsOneWidget);
+      expect(find.text('Applied stroke-rate ramp.'), findsOneWidget);
+
+      await tester.pump(const Duration(seconds: 4));
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Ramp split sec'),
+        '18',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Ramp strokes'),
+        '18',
+      );
+      await tester.enterText(find.widgetWithText(TextField, 'Ramp RPE'), '5');
+      await tester.tap(find.widgetWithText(FilledButton, 'Log Ramp Rep'));
+      await tester.pump();
+
+      expect(find.textContaining('Rep 1 · 60.0 spm'), findsOneWidget);
+      expect(find.textContaining('1.39m/stroke'), findsOneWidget);
+      expect(find.textContaining('Rep 2/2 64.0 spm'), findsOneWidget);
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Ramp split sec'),
+        '17',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Ramp strokes'),
+        '20',
+      );
+      await tester.enterText(find.widgetWithText(TextField, 'Ramp RPE'), '7');
+      await tester.tap(find.widgetWithText(FilledButton, 'Log Ramp Rep'));
+      await tester.pump();
+
+      expect(find.textContaining('Fastest 1:08/100m'), findsOneWidget);
+      await tester.pump(const Duration(seconds: 4));
+      await _scrollTo(tester, find.widgetWithText(FilledButton, 'Save Ramp'));
+      final saveRampButton = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Save Ramp'),
+      );
+      saveRampButton.onPressed!();
+      await tester.pump();
+
+      final captured = verify(
+        () => harness.dao.insertTempoSessionResult(captureAny()),
+      ).captured.single as TempoSessionResult;
+      expect(captured.mode, TempoMode.strokeRate);
+      expect(captured.actualSplits, const [
+        Duration(seconds: 18),
+        Duration(seconds: 17),
+      ]);
+      expect(captured.strokeCounts, [18, 20]);
+      expect(captured.rpe, 6);
+      expect(captured.notes, contains('rep 1: 60.0 spm'));
+      expect(captured.notes, contains('rep 2: 64.0 spm'));
     });
 
     testWidgets('saves a tempo result with actual splits', (tester) async {


### PR DESCRIPTION
## Summary
- add stroke-rate ramp protocol generation for start rate, increment, repeat distance, reps, and rest
- add Tempo Trainer UI for logging ramp split, stroke count, RPE, notes, and summary pace/rate/DPS
- save ramp reps through offline tempo session results

## Tests
- dart format lib test
- flutter test test/features/tempo test/database/dao_integration_test.dart test/core/sync/sync_payloads_test.dart
- flutter analyze
- flutter test

Closes #19