### PR TITLE
feat: add age-based medal standards view

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -12,4 +12,9 @@ Use these documents as the current source of truth for future development:
 - [Implementation Status & Roadmap](implementation-roadmap.md)
 - [Code Review Implementation Plan](code-review-implementation-plan.md)
 
+Feature documentation:
+
+- [Race Qualification Standards](../race-qualification-standards.md)
+- [Tempo Trainer](../tempo-trainer.md)
+
 The files in `docs/plans/` are retained as source/reference notes.

--- a/docs/design/consolidated-design.md
+++ b/docs/design/consolidated-design.md
@@ -89,8 +89,10 @@ lib/
     home/
     pb/
     profiles/
+    race/
     stopwatch/
     swim/
+    tempo/
   app.dart
   main.dart
 ```
@@ -169,6 +171,64 @@ Unique rule:
 ```text
 unique(profile_id, stroke, distance)
 ```
+
+### Race Times And Qualification Standards
+
+```text
+race_times
+- id
+- profile_id
+- race_name
+- event_date
+- distance
+- stroke
+- course_type
+- time_centiseconds
+- notes
+- placement
+- location
+- created_at
+- updated_at
+
+qualification_standards
+- id
+- profile_id
+- age
+- distance
+- stroke
+- course_type
+- gold_centiseconds
+- silver_centiseconds
+- bronze_centiseconds
+- created_at
+- updated_at
+
+meet_qualification_standards
+- id
+- source_name
+- sex
+- age_group_label
+- min_age
+- max_age
+- is_open
+- distance
+- stroke
+- course_type
+- qualifying_centiseconds
+- mc_points
+- is_relay
+- relay_event
+- valid_from
+- competition_start
+- competition_end
+```
+
+Manual qualification standards are profile-scoped medal thresholds by age,
+event, and course. The Qualification Standards screen includes an age selector
+and a gold/silver/bronze table for manual standards. Imported meet standards are
+separate local reference data and currently include the 2026/27 Uncloud
+Victorian Metro SC Championships source. See
+[Race Qualification Standards](../race-qualification-standards.md).
 
 ### Dryland
 

--- a/docs/design/implementation-roadmap.md
+++ b/docs/design/implementation-roadmap.md
@@ -66,6 +66,19 @@ This status reflects the current codebase after consolidating the PRD, V1 build 
 - PB rebuild after session deletion.
 - PB screen grouped by stroke.
 
+### Race Times & Qualification Standards
+
+- Race time logging with meet name, date, event, course, time, placement,
+  location, and notes.
+- Race time search, filters, sort options, mobile cards, and desktop table.
+- Manual qualification standards scoped to the active swimmer profile.
+- Manual standards store age, event, course, and gold/silver/bronze thresholds.
+- Qualification standard validation keeps gold faster than silver and bronze.
+- Qualification matching by profile, age, distance, stroke, and course.
+- Age-based medal standards table on the Qualification Standards screen.
+- Imported Victorian Metro SC 2026/27 meet standards as local reference data.
+- Local sync queue payloads for manual qualification standard mutations.
+
 ### Analytics
 
 - Total sessions.
@@ -120,6 +133,8 @@ This status reflects the current codebase after consolidating the PRD, V1 build 
 - Interval timer provider and widget tests.
 - Swim session widget tests.
 - Swim session detail widget tests.
+- Race time service, provider, and widget tests.
+- Qualification standard service, provider, widget, source, and DAO tests.
 - Dryland provider update test.
 - Sync payload tests.
 - Sync queue provider integration tests.

--- a/docs/race-qualification-standards.md
+++ b/docs/race-qualification-standards.md
@@ -1,0 +1,52 @@
+# Race Qualification Standards
+
+Race qualification standards live under the Race Times feature. From the Race
+Times screen, use the qualification standards action in the app bar to open the
+Qualification Standards screen.
+
+## Manual Medal Standards
+
+Manual standards are swimmer-profile scoped. Each standard stores:
+
+- age
+- distance
+- stroke
+- course
+- gold time
+- silver time
+- bronze time
+
+Gold must be the fastest threshold, followed by silver and then bronze. The app
+stores times as centiseconds and shows them in the same `mm:ss.cc` format used
+by race times.
+
+The screen includes a Medal standards by age panel when manual standards exist.
+Use the age selector to view the gold, silver, and bronze thresholds for that
+age in an event table. The table is sorted by age, distance, stroke, and course.
+
+## Race Matching
+
+Qualification matching uses the active swimmer profile, age, distance, stroke,
+and course. A race time earns the best qualifying tier it meets:
+
+- Gold when the race time is at or below the gold threshold.
+- Silver when it misses gold but is at or below the silver threshold.
+- Bronze when it misses silver but is at or below the bronze threshold.
+
+The matching service ignores standards with invalid medal ordering.
+
+## Imported Meet Standards
+
+Imported meet standards are separate from manual medal standards. The current
+import source is `2026/27 Uncloud Victorian Metro SC Championships`, extracted
+from `docs/qualify/qualify_time.pdf`.
+
+Imported standards can include sex, age bands, single qualifying times, MC point
+thresholds, and relay standards. They are stored in their own table and are not
+converted into manual gold/silver/bronze thresholds.
+
+## Sync
+
+Manual standards queue create, update, and delete mutations in the local sync
+queue as `qualification_standard` payloads. Imported meet standards are local
+reference data and are not currently queued for remote sync.

--- a/lib/features/race/domain/services/qualification_standard_service.dart
+++ b/lib/features/race/domain/services/qualification_standard_service.dart
@@ -21,6 +21,49 @@ bool hasValidQualificationOrder(QualificationStandard standard) {
       standard.silverTime <= standard.bronzeTime;
 }
 
+List<QualificationStandard> sortQualificationStandards(
+  List<QualificationStandard> standards,
+) {
+  final sorted = [...standards];
+  sorted.sort((a, b) {
+    final ageCompare = a.age.compareTo(b.age);
+    if (ageCompare != 0) return ageCompare;
+    final distanceCompare = a.distance.compareTo(b.distance);
+    if (distanceCompare != 0) return distanceCompare;
+    final strokeCompare = a.stroke.toLowerCase().compareTo(
+          b.stroke.toLowerCase(),
+        );
+    if (strokeCompare != 0) return strokeCompare;
+    return a.course.index.compareTo(b.course.index);
+  });
+  return sorted;
+}
+
+List<int> qualificationAges(List<QualificationStandard> standards) {
+  final ages = standards.map((standard) => standard.age).toSet().toList()
+    ..sort();
+  return ages;
+}
+
+Map<int, List<QualificationStandard>> qualificationStandardsByAge(
+  List<QualificationStandard> standards,
+) {
+  final grouped = <int, List<QualificationStandard>>{};
+  for (final standard in sortQualificationStandards(standards)) {
+    grouped.putIfAbsent(standard.age, () => []).add(standard);
+  }
+  return grouped;
+}
+
+List<QualificationStandard> qualificationStandardsForAge(
+  List<QualificationStandard> standards,
+  int age,
+) {
+  return sortQualificationStandards(
+    standards.where((standard) => standard.age == age).toList(),
+  );
+}
+
 QualificationTier? qualificationTierForTime(
   QualificationStandard standard,
   Duration raceTime,

--- a/lib/features/race/presentation/screens/qualification_standards_screen.dart
+++ b/lib/features/race/presentation/screens/qualification_standards_screen.dart
@@ -137,6 +137,8 @@ class QualificationStandardsScreen extends ConsumerWidget {
                 padding: const EdgeInsets.fromLTRB(16, 16, 16, 96),
                 children: [
                   if (standards.isNotEmpty) ...[
+                    _AgeMedalStandardsPanel(standards: standards),
+                    const SizedBox(height: 12),
                     const _SectionHeader(title: 'Manual medal standards'),
                     for (final standard in standards)
                       Padding(
@@ -170,6 +172,122 @@ class QualificationStandardsScreen extends ConsumerWidget {
         loading: () =>
             const Center(child: CircularProgressIndicator.adaptive()),
         error: (error, _) => Center(child: Text('Error: $error')),
+      ),
+    );
+  }
+}
+
+class _AgeMedalStandardsPanel extends StatefulWidget {
+  const _AgeMedalStandardsPanel({required this.standards});
+
+  final List<QualificationStandard> standards;
+
+  @override
+  State<_AgeMedalStandardsPanel> createState() =>
+      _AgeMedalStandardsPanelState();
+}
+
+class _AgeMedalStandardsPanelState extends State<_AgeMedalStandardsPanel> {
+  int? _selectedAge;
+
+  @override
+  Widget build(BuildContext context) {
+    final ages = qualificationAges(widget.standards);
+    if (ages.isEmpty) return const SizedBox.shrink();
+    final selectedAge = _selectedAge != null && ages.contains(_selectedAge)
+        ? _selectedAge!
+        : ages.first;
+    final ageStandards =
+        qualificationStandardsForAge(widget.standards, selectedAge);
+    final standardLabel = ageStandards.length == 1 ? 'standard' : 'standards';
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.workspace_premium_outlined),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Medal standards by age',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+                SizedBox(
+                  width: 140,
+                  child: DropdownButtonFormField<int>(
+                    isExpanded: true,
+                    initialValue: selectedAge,
+                    decoration: const InputDecoration(labelText: 'Age'),
+                    items: [
+                      for (final age in ages)
+                        DropdownMenuItem(
+                          value: age,
+                          child: Text('Age $age'),
+                        ),
+                    ],
+                    onChanged: (value) {
+                      if (value != null) {
+                        setState(() => _selectedAge = value);
+                      }
+                    },
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text('${ageStandards.length} $standardLabel for age $selectedAge'),
+            const SizedBox(height: 8),
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: DataTable(
+                columns: const [
+                  DataColumn(label: Text('Event')),
+                  DataColumn(label: Text('Course')),
+                  DataColumn(label: Text('Gold')),
+                  DataColumn(label: Text('Silver')),
+                  DataColumn(label: Text('Bronze')),
+                ],
+                rows: [
+                  for (final standard in ageStandards)
+                    DataRow(
+                      cells: [
+                        DataCell(
+                          Text('${standard.distance}m ${standard.stroke}'),
+                        ),
+                        DataCell(Text(standard.course.code)),
+                        DataCell(
+                          Text(
+                            DurationUtils.formatDurationWithCentiseconds(
+                              standard.goldTime,
+                            ),
+                          ),
+                        ),
+                        DataCell(
+                          Text(
+                            DurationUtils.formatDurationWithCentiseconds(
+                              standard.silverTime,
+                            ),
+                          ),
+                        ),
+                        DataCell(
+                          Text(
+                            DurationUtils.formatDurationWithCentiseconds(
+                              standard.bronzeTime,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/test/database/dao_integration_test.dart
+++ b/test/database/dao_integration_test.dart
@@ -433,17 +433,26 @@ void main() {
           bronzeTime: const Duration(seconds: 70),
         ),
       );
+      await dao.insertOrUpdate(
+        standard.copyWith(
+          id: 'standard-3',
+          age: 11,
+          distance: 50,
+          stroke: 'Backstroke',
+        ),
+      );
 
       final profileOneStandards = await dao.getAll('profile-1');
       final profileTwoStandards = await dao.getAll('profile-2');
-      expect(profileOneStandards, hasLength(1));
-      expect(profileOneStandards.single.distance, 100);
-      expect(
-          profileOneStandards.single.bronzeTime, const Duration(seconds: 70));
+      expect(profileOneStandards, hasLength(2));
+      expect(profileOneStandards.map((standard) => standard.age), [11, 12]);
+      expect(profileOneStandards.first.stroke, 'Backstroke');
+      expect(profileOneStandards.last.distance, 100);
+      expect(profileOneStandards.last.bronzeTime, const Duration(seconds: 70));
       expect(profileTwoStandards.single.id, 'standard-2');
 
       await dao.delete('standard-1', 'profile-1');
-      expect(await dao.getAll('profile-1'), isEmpty);
+      expect(await dao.getAll('profile-1'), hasLength(1));
       expect(await dao.getAll('profile-2'), hasLength(1));
     });
 

--- a/test/features/race/qualification_standard_service_test.dart
+++ b/test/features/race/qualification_standard_service_test.dart
@@ -63,12 +63,32 @@ void main() {
       expect(result?.tier, QualificationTier.silver);
       expect(result?.margin, const Duration(seconds: 1));
     });
+
+    test('groups and sorts medal standards by age and event', () {
+      final standards = [
+        _standard(age: 13, distance: 100, stroke: 'Backstroke'),
+        _standard(age: 12, distance: 100, stroke: 'Freestyle'),
+        _standard(age: 12, distance: 50, stroke: 'Butterfly'),
+        _standard(age: 12, distance: 50, stroke: 'Backstroke'),
+      ];
+
+      expect(qualificationAges(standards), [12, 13]);
+      expect(qualificationStandardsByAge(standards).keys, [12, 13]);
+
+      final age12 = qualificationStandardsForAge(standards, 12);
+      expect(
+        age12.map((standard) => '${standard.distance} ${standard.stroke}'),
+        ['50 Backstroke', '50 Butterfly', '100 Freestyle'],
+      );
+    });
   });
 }
 
 QualificationStandard _standard({
   String profileId = 'profile-1',
   int age = 12,
+  int distance = 50,
+  String stroke = 'Freestyle',
   RaceCourse course = RaceCourse.shortCourseMeters,
   Duration goldTime = const Duration(seconds: 30),
   Duration silverTime = const Duration(seconds: 32),
@@ -78,8 +98,8 @@ QualificationStandard _standard({
     id: 'standard-1',
     profileId: profileId,
     age: age,
-    distance: 50,
-    stroke: 'Freestyle',
+    distance: distance,
+    stroke: stroke,
     course: course,
     goldTime: goldTime,
     silverTime: silverTime,

--- a/test/features/race/qualification_standards_screen_test.dart
+++ b/test/features/race/qualification_standards_screen_test.dart
@@ -69,6 +69,27 @@ void main() {
       expect(find.text('Bronze: 00:35.00'), findsOneWidget);
     });
 
+    testWidgets('shows manual medal standards by selected age', (tester) async {
+      await _pumpStandards(tester, [
+        _standard(age: 12, distance: 50, stroke: 'Freestyle'),
+        _standard(age: 12, distance: 100, stroke: 'Backstroke'),
+        _standard(age: 13, distance: 200, stroke: 'Freestyle'),
+      ]);
+
+      expect(find.text('Medal standards by age'), findsOneWidget);
+      expect(find.text('2 standards for age 12'), findsOneWidget);
+      expect(find.text('Gold'), findsOneWidget);
+      expect(find.text('Silver'), findsOneWidget);
+      expect(find.text('Bronze'), findsOneWidget);
+
+      await tester.tap(find.text('Age 12').first);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Age 13').last);
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 standard for age 13'), findsOneWidget);
+    });
+
     testWidgets('validates medal order', (tester) async {
       await _pumpStandards(tester, []);
 
@@ -137,13 +158,17 @@ Future<void> _pumpStandards(
   await tester.pump();
 }
 
-QualificationStandard _standard() {
+QualificationStandard _standard({
+  int age = 12,
+  int distance = 50,
+  String stroke = 'Freestyle',
+}) {
   return QualificationStandard(
-    id: 'standard-1',
+    id: 'standard-$age-$distance-$stroke',
     profileId: 'profile-1',
-    age: 12,
-    distance: 50,
-    stroke: 'Freestyle',
+    age: age,
+    distance: distance,
+    stroke: stroke,
     course: RaceCourse.shortCourseMeters,
     goldTime: const Duration(seconds: 30),
     silverTime: const Duration(seconds: 32),


### PR DESCRIPTION
## Summary
- add qualification standard helpers for age grouping and event sorting
- add an age selector and gold/silver/bronze standards table to the Qualification Standards screen
- extend widget, unit, and DAO integration tests for age-based medal standards
- document race qualification standards in the feature docs and design/status docs

## Tests
- dart format lib test
- flutter test test/features/race/qualification_standard_service_test.dart test/features/race/qualification_standards_screen_test.dart test/database/dao_integration_test.dart
- flutter analyze
- flutter test

Closes #11