### PR TITLE
feat: add coach mode for sharing swimmer details

### DIFF
--- a/docs/superpowers/plans/2026-05-16-coach-mode.md
+++ b/docs/superpowers/plans/2026-05-16-coach-mode.md
@@ -1,0 +1,1383 @@
+# Coach Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a coach mode to repSwim that lets a swimmer share selected profiles and data categories with a coach through a sealed on-device read-only view and a PDF export.
+
+**Architecture:** A new `lib/features/coach/` module (domain/data/presentation) backed by a new `coach_shares` SQLite table. A single `CoachReportBuilder` assembles the shared data once; both the on-device coach view and the `CoachPdfBuilder` consume that report so they cannot diverge.
+
+**Tech Stack:** Flutter, Dart, Riverpod, sqflite, go_router; new dependencies `pdf` and `printing`.
+
+---
+
+## Conventions (read once before starting)
+
+### Testing
+
+The project uses `flutter_test`. `test/` mirrors `lib/` one-for-one. Run the
+whole suite with `flutter test`; a single file with
+`flutter test test/path/to/file.dart`. The pre-PR gate is
+`flutter analyze && flutter test`.
+
+DAO/database tests use the in-memory database: `AppDatabase.test()` (see
+`lib/database/app_database.dart`) — each test constructs a fresh instance.
+See `test/database/dao_integration_test.dart` for the established pattern.
+
+### Codebase patterns
+
+- **DAOs** live in `lib/database/daos/`, take an `AppDatabase` in a `const`
+  constructor, and obtain the `Database` via `await _db.database`.
+- **Entities** are immutable, in `domain/entities/`, `PascalCase` types,
+  `snake_case.dart` files. British spelling in code and comments.
+- **Providers** live in a feature's `presentation/providers/`, named
+  `<noun>Provider`. DAO providers do `Provider((ref) => Dao(AppDatabase.instance))`.
+- **Lint:** `prefer_const_constructors` and `prefer_const_literals` are
+  enforced — the build fails otherwise. Run `dart format lib test` before
+  committing.
+- **Commits:** conventional (`feat:`, `test:`, `docs:`). No mention of AI
+  tooling; no co-author trailers.
+
+### Category set
+
+`CoachShareCategory` has exactly eight values throughout this plan:
+`profileDetails`, `goals`, `notes`, `swimSessions`, `raceTimes`,
+`personalBests`, `analytics`, `dryland`.
+
+---
+
+## Task 1: Add PDF dependencies
+
+**Files:**
+- Modify: `pubspec.yaml`
+
+- [ ] **Step 1: Add `pdf` and `printing` to dependencies**
+
+In `pubspec.yaml`, under `dependencies:`, add after `path: ^1.9.0`:
+
+```yaml
+  pdf: ^3.11.0
+  printing: ^5.13.0
+```
+
+- [ ] **Step 2: Fetch packages**
+
+Run: `dart pub get`
+Expected: exit 0, both packages resolved.
+
+NOTE: If a version does not resolve against the Dart 3 / Flutter SDK in this
+environment, pick the latest `pdf` 3.x and `printing` 5.x that resolve and
+record the chosen versions.
+
+- [ ] **Step 3: Verify the project still analyses**
+
+Run: `flutter analyze`
+Expected: no new issues.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pubspec.yaml pubspec.lock
+git commit -m "build: add pdf and printing dependencies for coach mode (#10)"
+```
+
+---
+
+## Task 2: CoachShareCategory enum
+
+**Files:**
+- Create: `lib/features/coach/domain/entities/coach_share_category.dart`
+- Test: `test/features/coach/domain/coach_share_category_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share_category.dart';
+
+void main() {
+  group('CoachShareCategory', () {
+    test('exposes eight categories', () {
+      expect(CoachShareCategory.values.length, 8);
+    });
+
+    test('every category has a unique non-empty key and label', () {
+      final keys = CoachShareCategory.values.map((c) => c.key).toSet();
+      expect(keys.length, 8);
+      for (final c in CoachShareCategory.values) {
+        expect(c.key, isNotEmpty);
+        expect(c.label, isNotEmpty);
+      }
+    });
+
+    test('fromKey round-trips every category', () {
+      for (final c in CoachShareCategory.values) {
+        expect(CoachShareCategory.fromKey(c.key), c);
+      }
+    });
+
+    test('fromKey returns null for an unknown key', () {
+      expect(CoachShareCategory.fromKey('not_a_category'), isNull);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/coach/domain/coach_share_category_test.dart`
+Expected: FAIL — file/type does not exist.
+
+- [ ] **Step 3: Implement the enum**
+
+```dart
+/// A category of swimmer data that can be shared with a coach.
+///
+/// [key] is the stable identifier persisted in the database; [label] is the
+/// human-readable name shown in the UI.
+enum CoachShareCategory {
+  profileDetails('profile_details', 'Profile details'),
+  goals('goals', 'Goals'),
+  notes('notes', 'Notes'),
+  swimSessions('swim_sessions', 'Swim sessions'),
+  raceTimes('race_times', 'Race times'),
+  personalBests('personal_bests', 'Personal bests'),
+  analytics('analytics', 'Analytics'),
+  dryland('dryland', 'Dryland training');
+
+  const CoachShareCategory(this.key, this.label);
+
+  final String key;
+  final String label;
+
+  /// Returns the category with the given [key], or null if none matches.
+  static CoachShareCategory? fromKey(String key) {
+    for (final category in values) {
+      if (category.key == key) return category;
+    }
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/coach/domain/coach_share_category_test.dart`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/coach/domain/entities/coach_share_category.dart test/features/coach/domain/coach_share_category_test.dart
+git commit -m "feat: add CoachShareCategory enum (#10)"
+```
+
+---
+
+## Task 3: CoachShare entity
+
+**Files:**
+- Create: `lib/features/coach/domain/entities/coach_share.dart`
+- Test: `test/features/coach/domain/coach_share_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share_category.dart';
+
+void main() {
+  group('CoachShare', () {
+    test('a profile with no row is not sharing anything', () {
+      const share = CoachShare(profileId: 'p1');
+      expect(share.enabled, isFalse);
+      expect(share.hasActiveSharing, isFalse);
+      expect(share.isShared(CoachShareCategory.goals), isFalse);
+    });
+
+    test('isShared requires both the master flag and the category', () {
+      const disabled = CoachShare(
+        profileId: 'p1',
+        sharedCategories: {CoachShareCategory.goals},
+      );
+      expect(disabled.isShared(CoachShareCategory.goals), isFalse,
+          reason: 'master flag off means nothing is shared');
+
+      const enabled = CoachShare(
+        profileId: 'p1',
+        enabled: true,
+        sharedCategories: {CoachShareCategory.goals},
+      );
+      expect(enabled.isShared(CoachShareCategory.goals), isTrue);
+      expect(enabled.isShared(CoachShareCategory.notes), isFalse);
+    });
+
+    test('withCategory and withoutCategory return updated copies', () {
+      const base = CoachShare(profileId: 'p1', enabled: true);
+      final added = base.withCategory(CoachShareCategory.notes);
+      expect(added.sharedCategories, {CoachShareCategory.notes});
+      expect(base.sharedCategories, isEmpty, reason: 'original unchanged');
+
+      final removed = added.withoutCategory(CoachShareCategory.notes);
+      expect(removed.sharedCategories, isEmpty);
+    });
+
+    test('activeCategories is empty when the master flag is off', () {
+      const share = CoachShare(
+        profileId: 'p1',
+        sharedCategories: {CoachShareCategory.goals},
+      );
+      expect(share.activeCategories, isEmpty);
+    });
+
+    test('hasActiveSharing is true only when enabled with a category', () {
+      const enabledNoCategories = CoachShare(profileId: 'p1', enabled: true);
+      expect(enabledNoCategories.hasActiveSharing, isFalse);
+
+      const enabledWithCategory = CoachShare(
+        profileId: 'p1',
+        enabled: true,
+        sharedCategories: {CoachShareCategory.dryland},
+      );
+      expect(enabledWithCategory.hasActiveSharing, isTrue);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/coach/domain/coach_share_test.dart`
+Expected: FAIL — file/type does not exist.
+
+- [ ] **Step 3: Implement the entity**
+
+```dart
+import 'coach_share_category.dart';
+
+/// The coach-sharing configuration for a single swimmer profile.
+///
+/// Sharing is opt-in: nothing is shared unless [enabled] is true *and* the
+/// category is present in [sharedCategories].
+class CoachShare {
+  const CoachShare({
+    required this.profileId,
+    this.enabled = false,
+    this.sharedCategories = const {},
+  });
+
+  final String profileId;
+  final bool enabled;
+  final Set<CoachShareCategory> sharedCategories;
+
+  /// Whether [category] is actually shared (master flag on and ticked).
+  bool isShared(CoachShareCategory category) =>
+      enabled && sharedCategories.contains(category);
+
+  /// The categories actually shared right now — empty when [enabled] is false.
+  Set<CoachShareCategory> get activeCategories =>
+      enabled ? Set.unmodifiable(sharedCategories) : const {};
+
+  /// True when this profile shares at least one category with a coach.
+  bool get hasActiveSharing => enabled && sharedCategories.isNotEmpty;
+
+  CoachShare withCategory(CoachShareCategory category) => copyWith(
+        sharedCategories: {...sharedCategories, category},
+      );
+
+  CoachShare withoutCategory(CoachShareCategory category) => copyWith(
+        sharedCategories: {...sharedCategories}..remove(category),
+      );
+
+  CoachShare copyWith({
+    bool? enabled,
+    Set<CoachShareCategory>? sharedCategories,
+  }) {
+    return CoachShare(
+      profileId: profileId,
+      enabled: enabled ?? this.enabled,
+      sharedCategories: sharedCategories ?? this.sharedCategories,
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/coach/domain/coach_share_test.dart`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/coach/domain/entities/coach_share.dart test/features/coach/domain/coach_share_test.dart
+git commit -m "feat: add CoachShare entity (#10)"
+```
+
+---
+
+## Task 4: Database migration to v13 (coach_shares table)
+
+**Files:**
+- Modify: `lib/core/constants/app_constants.dart` (line 13: `kDbVersion`)
+- Modify: `lib/database/app_database.dart`
+- Test: `test/database/coach_shares_migration_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/database/app_database.dart';
+
+void main() {
+  test('coach_shares table exists with the expected columns', () async {
+    final db = AppDatabase.test();
+    final database = await db.database;
+
+    final tables = await database.rawQuery(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='coach_shares'",
+    );
+    expect(tables, hasLength(1), reason: 'coach_shares table must exist');
+
+    final columns = await database.rawQuery('PRAGMA table_info(coach_shares)');
+    final names = columns.map((row) => row['name'] as String).toSet();
+    expect(names, containsAll(<String>[
+      'profile_id',
+      'enabled',
+      'shared_categories_json',
+      'updated_at',
+    ]));
+
+    await db.close();
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/database/coach_shares_migration_test.dart`
+Expected: FAIL — no `coach_shares` table.
+
+- [ ] **Step 3: Bump the schema version**
+
+In `lib/core/constants/app_constants.dart`, change line 13 from
+`const int kDbVersion = 12;` to `const int kDbVersion = 13;`.
+
+- [ ] **Step 4: Add the table creator and wire it into create/upgrade**
+
+In `lib/database/app_database.dart`, add this method alongside the other
+`_createXTable` methods:
+
+```dart
+  Future<void> _createCoachSharesTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS coach_shares (
+        profile_id TEXT PRIMARY KEY,
+        enabled INTEGER NOT NULL DEFAULT 0,
+        shared_categories_json TEXT NOT NULL DEFAULT '[]',
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY (profile_id)
+          REFERENCES swimmer_profiles(id) ON DELETE CASCADE
+      )
+    ''');
+  }
+```
+
+In `_onCreate`, add a call after `_createMeetQualificationStandardsTable(db);`:
+
+```dart
+    await _createCoachSharesTable(db);
+```
+
+In `_onUpgrade`, add a new branch after the `if (oldVersion < 12)` block:
+
+```dart
+    if (oldVersion < 13) {
+      await _createCoachSharesTable(db);
+    }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `flutter test test/database/coach_shares_migration_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full database test suite for regressions**
+
+Run: `flutter test test/database/`
+Expected: PASS — the version bump must not break existing migration tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/core/constants/app_constants.dart lib/database/app_database.dart test/database/coach_shares_migration_test.dart
+git commit -m "feat: add coach_shares table in schema v13 (#10)"
+```
+
+---
+
+## Task 5: CoachShareDao
+
+**Files:**
+- Create: `lib/database/daos/coach_share_dao.dart`
+- Test: `test/database/coach_share_dao_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/database/app_database.dart';
+import 'package:rep_swim/database/daos/coach_share_dao.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share_category.dart';
+
+void main() {
+  late AppDatabase db;
+  late CoachShareDao dao;
+
+  setUp(() {
+    db = AppDatabase.test();
+    dao = CoachShareDao(db);
+  });
+
+  tearDown(() => db.close());
+
+  test('getForProfile returns a disabled default when no row exists', () async {
+    final share = await dao.getForProfile('local-default-profile');
+    expect(share.profileId, 'local-default-profile');
+    expect(share.enabled, isFalse);
+    expect(share.sharedCategories, isEmpty);
+  });
+
+  test('save then getForProfile round-trips enabled state and categories',
+      () async {
+    const share = CoachShare(
+      profileId: 'local-default-profile',
+      enabled: true,
+      sharedCategories: {
+        CoachShareCategory.goals,
+        CoachShareCategory.swimSessions,
+      },
+    );
+    await dao.save(share);
+
+    final loaded = await dao.getForProfile('local-default-profile');
+    expect(loaded.enabled, isTrue);
+    expect(loaded.sharedCategories, {
+      CoachShareCategory.goals,
+      CoachShareCategory.swimSessions,
+    });
+  });
+
+  test('save overwrites a previous configuration', () async {
+    await dao.save(const CoachShare(
+      profileId: 'local-default-profile',
+      enabled: true,
+      sharedCategories: {CoachShareCategory.notes},
+    ));
+    await dao.save(const CoachShare(
+      profileId: 'local-default-profile',
+      enabled: false,
+    ));
+    final loaded = await dao.getForProfile('local-default-profile');
+    expect(loaded.enabled, isFalse);
+    expect(loaded.sharedCategories, isEmpty);
+  });
+
+  test('getSharedProfileIds lists only profiles with active sharing',
+      () async {
+    await dao.save(const CoachShare(
+      profileId: 'local-default-profile',
+      enabled: true,
+      sharedCategories: {CoachShareCategory.goals},
+    ));
+    final ids = await dao.getSharedProfileIds();
+    expect(ids, contains('local-default-profile'));
+  });
+
+  test('unknown category keys in storage are ignored on read', () async {
+    final database = await db.database;
+    await database.insert('coach_shares', {
+      'profile_id': 'local-default-profile',
+      'enabled': 1,
+      'shared_categories_json': '["goals","bogus_category"]',
+      'updated_at': DateTime.now().millisecondsSinceEpoch,
+    });
+    final loaded = await dao.getForProfile('local-default-profile');
+    expect(loaded.sharedCategories, {CoachShareCategory.goals});
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/database/coach_share_dao_test.dart`
+Expected: FAIL — `CoachShareDao` does not exist.
+
+- [ ] **Step 3: Implement the DAO**
+
+```dart
+import 'dart:convert';
+
+import 'package:sqflite/sqflite.dart';
+
+import '../../features/coach/domain/entities/coach_share.dart';
+import '../../features/coach/domain/entities/coach_share_category.dart';
+import '../app_database.dart';
+
+/// Persistence for per-profile coach-sharing configuration.
+class CoachShareDao {
+  const CoachShareDao(this._db);
+
+  final AppDatabase _db;
+
+  /// Returns the sharing configuration for [profileId]. A profile with no
+  /// stored row yields a disabled [CoachShare] with no categories.
+  Future<CoachShare> getForProfile(String profileId) async {
+    final db = await _db.database;
+    final rows = await db.query(
+      'coach_shares',
+      where: 'profile_id = ?',
+      whereArgs: [profileId],
+      limit: 1,
+    );
+    if (rows.isEmpty) return CoachShare(profileId: profileId);
+    return _fromRow(rows.first);
+  }
+
+  /// Inserts or replaces the configuration for the share's profile.
+  Future<void> save(CoachShare share) async {
+    final db = await _db.database;
+    await db.insert(
+      'coach_shares',
+      {
+        'profile_id': share.profileId,
+        'enabled': share.enabled ? 1 : 0,
+        'shared_categories_json': jsonEncode(
+          share.sharedCategories.map((c) => c.key).toList(),
+        ),
+        'updated_at': DateTime.now().toUtc().millisecondsSinceEpoch,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  /// Removes any stored configuration for [profileId].
+  Future<void> delete(String profileId) async {
+    final db = await _db.database;
+    await db.delete(
+      'coach_shares',
+      where: 'profile_id = ?',
+      whereArgs: [profileId],
+    );
+  }
+
+  /// IDs of profiles that currently share at least one category.
+  Future<List<String>> getSharedProfileIds() async {
+    final db = await _db.database;
+    final rows = await db.query('coach_shares', where: 'enabled = 1');
+    return rows
+        .map(_fromRow)
+        .where((share) => share.hasActiveSharing)
+        .map((share) => share.profileId)
+        .toList();
+  }
+
+  CoachShare _fromRow(Map<String, Object?> row) {
+    return CoachShare(
+      profileId: row['profile_id'] as String,
+      enabled: (row['enabled'] as int) == 1,
+      sharedCategories: _decodeCategories(
+        row['shared_categories_json'] as String?,
+      ),
+    );
+  }
+
+  Set<CoachShareCategory> _decodeCategories(String? value) {
+    if (value == null || value.isEmpty) return const {};
+    try {
+      final decoded = jsonDecode(value);
+      if (decoded is! List) return const {};
+      return decoded
+          .whereType<String>()
+          .map(CoachShareCategory.fromKey)
+          .whereType<CoachShareCategory>()
+          .toSet();
+    } on FormatException {
+      return const {};
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/database/coach_share_dao_test.dart`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/database/daos/coach_share_dao.dart test/database/coach_share_dao_test.dart
+git commit -m "feat: add CoachShareDao (#10)"
+```
+
+---
+
+## Task 6: Coach providers
+
+**Files:**
+- Create: `lib/features/coach/presentation/providers/coach_providers.dart`
+- Test: `test/features/coach/presentation/coach_providers_test.dart`
+
+The DAO is used directly by providers — there is no separate repository class,
+matching how `profile_providers.dart` consumes `ProfileDao` directly.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/database/app_database.dart';
+import 'package:rep_swim/database/daos/coach_share_dao.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share_category.dart';
+import 'package:rep_swim/features/coach/presentation/providers/coach_providers.dart';
+
+void main() {
+  test('CoachShareController loads, toggles, and persists a profile share',
+      () async {
+    final db = AppDatabase.test();
+    addTearDown(db.close);
+    final dao = CoachShareDao(db);
+
+    final container = ProviderContainer(overrides: [
+      coachShareDaoProvider.overrideWithValue(dao),
+    ]);
+    addTearDown(container.dispose);
+
+    final controller =
+        container.read(coachShareControllerProvider('p1').notifier);
+    await controller.future;
+
+    await controller.setEnabled(true);
+    await controller.setCategory(CoachShareCategory.goals, true);
+
+    final reloaded = await dao.getForProfile('p1');
+    expect(reloaded.enabled, isTrue);
+    expect(reloaded.isShared(CoachShareCategory.goals), isTrue);
+  });
+
+  test('stopSharing disables sharing for the profile', () async {
+    final db = AppDatabase.test();
+    addTearDown(db.close);
+    final dao = CoachShareDao(db);
+    await dao.save(const CoachShare(
+      profileId: 'p1',
+      enabled: true,
+      sharedCategories: {CoachShareCategory.notes},
+    ));
+
+    final container = ProviderContainer(overrides: [
+      coachShareDaoProvider.overrideWithValue(dao),
+    ]);
+    addTearDown(container.dispose);
+
+    final controller =
+        container.read(coachShareControllerProvider('p1').notifier);
+    await controller.future;
+    await controller.stopSharing();
+
+    expect((await dao.getForProfile('p1')).enabled, isFalse);
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/coach/presentation/coach_providers_test.dart`
+Expected: FAIL — providers do not exist.
+
+- [ ] **Step 3: Implement the providers**
+
+```dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../database/app_database.dart';
+import '../../../../database/daos/coach_share_dao.dart';
+import '../../domain/entities/coach_share.dart';
+import '../../domain/entities/coach_share_category.dart';
+
+/// DAO for coach-sharing configuration.
+final coachShareDaoProvider = Provider<CoachShareDao>((ref) {
+  return CoachShareDao(AppDatabase.instance);
+});
+
+/// IDs of profiles that currently share data with a coach.
+final sharedProfileIdsProvider = FutureProvider<List<String>>((ref) {
+  return ref.watch(coachShareDaoProvider).getSharedProfileIds();
+});
+
+/// Editable coach-sharing state for a single profile, keyed by profile id.
+final coachShareControllerProvider = AsyncNotifierProvider.family<
+    CoachShareController, CoachShare, String>(CoachShareController.new);
+
+class CoachShareController extends FamilyAsyncNotifier<CoachShare, String> {
+  @override
+  Future<CoachShare> build(String profileId) {
+    return ref.read(coachShareDaoProvider).getForProfile(profileId);
+  }
+
+  Future<void> _persist(CoachShare share) async {
+    await ref.read(coachShareDaoProvider).save(share);
+    state = AsyncData(share);
+    ref.invalidate(sharedProfileIdsProvider);
+  }
+
+  /// Turns the master "share with coach" flag on or off.
+  Future<void> setEnabled(bool enabled) async {
+    final current = state.value ?? CoachShare(profileId: arg);
+    await _persist(current.copyWith(enabled: enabled));
+  }
+
+  /// Adds or removes a single shared category.
+  Future<void> setCategory(CoachShareCategory category, bool shared) async {
+    final current = state.value ?? CoachShare(profileId: arg);
+    await _persist(
+      shared ? current.withCategory(category) : current.withoutCategory(category),
+    );
+  }
+
+  /// Disables all sharing for this profile.
+  Future<void> stopSharing() async {
+    final current = state.value ?? CoachShare(profileId: arg);
+    await _persist(current.copyWith(enabled: false));
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/coach/presentation/coach_providers_test.dart`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/coach/presentation/providers/coach_providers.dart test/features/coach/presentation/coach_providers_test.dart
+git commit -m "feat: add coach-sharing providers (#10)"
+```
+
+---
+
+## Task 7: CoachReport model
+
+**Files:**
+- Create: `lib/features/coach/domain/entities/coach_report.dart`
+- Test: `test/features/coach/domain/coach_report_test.dart`
+
+First read the entity types this model aggregates, so the field types are
+exact: `lib/features/swim/domain/entities/swim_session.dart`,
+`lib/features/race/domain/entities/race_time.dart`,
+`lib/features/pb/domain/entities/` (the personal-best entity),
+`lib/features/dryland/domain/entities/dryland_workout.dart`, and the analytics
+result type produced by `computeAnalytics` in
+`lib/features/analytics/presentation/providers/analytics_providers.dart`.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_report.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share_category.dart';
+import 'package:rep_swim/features/profiles/domain/entities/swimmer_profile.dart';
+
+void main() {
+  test('a report exposes exactly the categories it was built with', () {
+    final report = CoachReport(
+      profile: SwimmerProfile.defaultProfile,
+      includedCategories: const {
+        CoachShareCategory.goals,
+        CoachShareCategory.swimSessions,
+      },
+      swimSessions: const [],
+    );
+    expect(report.includes(CoachShareCategory.goals), isTrue);
+    expect(report.includes(CoachShareCategory.notes), isFalse);
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/coach/domain/coach_report_test.dart`
+Expected: FAIL — `CoachReport` does not exist.
+
+- [ ] **Step 3: Implement the model**
+
+Create an immutable `CoachReport` that holds the `SwimmerProfile`, a
+`Set<CoachShareCategory> includedCategories`, and one nullable field per
+data category, typed to the entities read above:
+
+```dart
+import '../../../profiles/domain/entities/swimmer_profile.dart';
+// ... import the swim session, race time, personal best, dryland workout,
+// and analytics result types using their real paths and names.
+import 'coach_share_category.dart';
+
+/// A read-only snapshot of one profile's shared data, assembled once and
+/// consumed by both the coach view and the PDF builder.
+class CoachReport {
+  const CoachReport({
+    required this.profile,
+    required this.includedCategories,
+    this.swimSessions,
+    this.raceTimes,
+    this.personalBests,
+    this.dryland,
+    this.analytics,
+  });
+
+  final SwimmerProfile profile;
+  final Set<CoachShareCategory> includedCategories;
+
+  // Each is non-null only when its category is in [includedCategories].
+  // Use the real entity types from the files read in this task.
+  final List<Object>? swimSessions;
+  final List<Object>? raceTimes;
+  final List<Object>? personalBests;
+  final List<Object>? dryland;
+  final Object? analytics;
+
+  bool includes(CoachShareCategory category) =>
+      includedCategories.contains(category);
+}
+```
+
+Replace the `Object`/`Object?` placeholders with the concrete entity types
+(for example `List<SwimSession>?`). `profileDetails`, `goals`, and `notes`
+draw from fields already on `profile`, so they need no extra field — they are
+tracked only through `includedCategories`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/coach/domain/coach_report_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/coach/domain/entities/coach_report.dart test/features/coach/domain/coach_report_test.dart
+git commit -m "feat: add CoachReport model (#10)"
+```
+
+---
+
+## Task 8: CoachReportBuilder
+
+**Files:**
+- Create: `lib/features/coach/domain/services/coach_report_builder.dart`
+- Test: `test/features/coach/domain/coach_report_builder_test.dart`
+
+The builder takes the DAOs it needs (swim session, race time, PB, dryland) and
+a profile lookup. For each category in the share's `activeCategories` it loads
+that category's data scoped to the profile id; categories not shared are left
+null. For `analytics` it runs the existing `computeAnalytics` over the
+profile's sessions and personal bests. `profileDetails`/`goals`/`notes` need no
+data load — they are flags only.
+
+- [ ] **Step 1: Write the failing test**
+
+The test must prove two things — **only shared categories appear**, and
+**only the target profile's data appears**. Read the DAO constructors and
+methods (`SwimSessionDao`, `RaceTimeDao`, `PbDao`, `DrylandDao` in
+`lib/database/daos/`) and seed the in-memory database with data for two
+profiles.
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/database/app_database.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share_category.dart';
+import 'package:rep_swim/features/coach/domain/services/coach_report_builder.dart';
+// import the DAOs and entity types needed to seed data.
+
+void main() {
+  test('builds a report containing only shared categories', () async {
+    final db = AppDatabase.test();
+    addTearDown(db.close);
+    // Seed profile 'p1' with at least one swim session and one race time.
+    // Build a CoachReportBuilder wired to the DAOs.
+
+    const share = CoachShare(
+      profileId: 'p1',
+      enabled: true,
+      sharedCategories: {CoachShareCategory.swimSessions},
+    );
+    final report = await builder.build('p1', share);
+
+    expect(report.includes(CoachShareCategory.swimSessions), isTrue);
+    expect(report.swimSessions, isNotNull);
+    expect(report.includes(CoachShareCategory.raceTimes), isFalse);
+    expect(report.raceTimes, isNull,
+        reason: 'an unshared category must not be loaded');
+  });
+
+  test('a report for p1 never contains p2 data (profile scoping)', () async {
+    final db = AppDatabase.test();
+    addTearDown(db.close);
+    // Seed swim sessions for both 'p1' and 'p2'.
+
+    const share = CoachShare(
+      profileId: 'p1',
+      enabled: true,
+      sharedCategories: {CoachShareCategory.swimSessions},
+    );
+    final report = await builder.build('p1', share);
+
+    // Every loaded session must belong to p1.
+    for (final session in report.swimSessions!) {
+      expect((session as dynamic).profileId, 'p1');
+    }
+  });
+}
+```
+
+Fill in the DAO wiring and seeding using the real DAO APIs.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/coach/domain/coach_report_builder_test.dart`
+Expected: FAIL — `CoachReportBuilder` does not exist.
+
+- [ ] **Step 3: Implement the builder**
+
+Create `CoachReportBuilder` with a constructor taking the DAOs and a way to
+resolve a `SwimmerProfile` by id. Implement
+`Future<CoachReport> build(String profileId, CoachShare share)`:
+
+1. Resolve the `SwimmerProfile` for `profileId`.
+2. Start from `share.activeCategories` (empty when the share is disabled).
+3. For each data-backed category in that set, load via the matching DAO
+   scoped to `profileId`; leave others null.
+4. For `analytics`, call `computeAnalytics` with the profile's sessions and
+   personal bests.
+5. Return a `CoachReport` whose `includedCategories` is exactly
+   `share.activeCategories`.
+
+The builder must never read data for a category absent from
+`share.activeCategories`, and every DAO call must be scoped by `profileId`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/coach/domain/coach_report_builder_test.dart`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/coach/domain/services/coach_report_builder.dart test/features/coach/domain/coach_report_builder_test.dart
+git commit -m "feat: add CoachReportBuilder (#10)"
+```
+
+---
+
+## Task 9: CoachPdfBuilder
+
+**Files:**
+- Create: `lib/features/coach/domain/services/coach_pdf_builder.dart`
+- Test: `test/features/coach/domain/coach_pdf_builder_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_report.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share_category.dart';
+import 'package:rep_swim/features/coach/domain/services/coach_pdf_builder.dart';
+import 'package:rep_swim/features/profiles/domain/entities/swimmer_profile.dart';
+
+void main() {
+  test('builds a non-empty PDF for a report', () async {
+    final report = CoachReport(
+      profile: SwimmerProfile.defaultProfile,
+      includedCategories: const {CoachShareCategory.profileDetails},
+    );
+    final bytes = await const CoachPdfBuilder().build(report);
+    expect(bytes, isNotEmpty);
+    // A PDF file starts with the "%PDF" magic bytes.
+    expect(String.fromCharCodes(bytes.take(4)), '%PDF');
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/coach/domain/coach_pdf_builder_test.dart`
+Expected: FAIL — `CoachPdfBuilder` does not exist.
+
+- [ ] **Step 3: Implement the builder**
+
+Create `CoachPdfBuilder` with `Future<Uint8List> build(CoachReport report)`.
+Use the `pdf` package (`pw.Document`). Render a header with the swimmer's
+display name and the included category labels, then one section per included
+category. Only iterate `report.includedCategories`. Return `document.save()`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/coach/domain/coach_pdf_builder_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/coach/domain/services/coach_pdf_builder.dart test/features/coach/domain/coach_pdf_builder_test.dart
+git commit -m "feat: add CoachPdfBuilder (#10)"
+```
+
+---
+
+## Task 10: Coach sharing settings screen
+
+**Files:**
+- Create: `lib/features/coach/presentation/screens/coach_sharing_settings_screen.dart`
+- Test: `test/features/coach/presentation/coach_sharing_settings_screen_test.dart`
+
+Read an existing screen (for example
+`lib/features/settings/presentation/screens/sync_settings_screen.dart`) for
+the `ConsumerWidget`/`Scaffold` house style.
+
+`CoachSharingSettingsScreen` takes a `profileId`. It watches
+`coachShareControllerProvider(profileId)` and renders:
+
+- A master `SwitchListTile` — *Share with coach* — bound to `setEnabled`.
+- When enabled, a `SwitchListTile` per `CoachShareCategory` (label from
+  `category.label`), each bound to `setCategory`.
+- A caution note that notes and personal details are shared only when
+  switched on.
+- A summary line listing the currently shared category labels.
+- A *Stop sharing* button bound to `stopSharing`.
+
+- [ ] **Step 1: Write the failing widget test**
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/database/app_database.dart';
+import 'package:rep_swim/database/daos/coach_share_dao.dart';
+import 'package:rep_swim/features/coach/presentation/providers/coach_providers.dart';
+import 'package:rep_swim/features/coach/presentation/screens/coach_sharing_settings_screen.dart';
+
+void main() {
+  testWidgets('enabling sharing reveals the category toggles', (tester) async {
+    final db = AppDatabase.test();
+    addTearDown(db.close);
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        coachShareDaoProvider.overrideWithValue(CoachShareDao(db)),
+      ],
+      child: const MaterialApp(
+        home: CoachSharingSettingsScreen(profileId: 'p1'),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Goals'), findsNothing,
+        reason: 'category toggles hidden while sharing is off');
+
+    await tester.tap(find.byType(SwitchListTile).first);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Goals'), findsOneWidget);
+  });
+
+  testWidgets('Stop sharing turns the master switch off', (tester) async {
+    final db = AppDatabase.test();
+    addTearDown(db.close);
+    await CoachShareDao(db).save(/* an enabled CoachShare for 'p1' */);
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        coachShareDaoProvider.overrideWithValue(CoachShareDao(db)),
+      ],
+      child: const MaterialApp(
+        home: CoachSharingSettingsScreen(profileId: 'p1'),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Stop sharing'));
+    await tester.pumpAndSettle();
+
+    expect((await CoachShareDao(db).getForProfile('p1')).enabled, isFalse);
+  });
+}
+```
+
+Fill the `save(...)` argument with an enabled `CoachShare` (see Task 5's test
+for the constructor).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/coach/presentation/coach_sharing_settings_screen_test.dart`
+Expected: FAIL — screen does not exist.
+
+- [ ] **Step 3: Implement the screen**
+
+Build `CoachSharingSettingsScreen` as described above. Hide the category
+toggles, summary, and *Stop sharing* button while the master switch is off.
+Keep widgets `const` where the lint requires it.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/coach/presentation/coach_sharing_settings_screen_test.dart`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/coach/presentation/screens/coach_sharing_settings_screen.dart test/features/coach/presentation/coach_sharing_settings_screen_test.dart
+git commit -m "feat: add coach sharing settings screen (#10)"
+```
+
+---
+
+## Task 11: Coach view screen
+
+**Files:**
+- Create: `lib/features/coach/presentation/screens/coach_view_screen.dart`
+- Create: `lib/features/coach/presentation/providers/coach_report_providers.dart`
+- Test: `test/features/coach/presentation/coach_view_screen_test.dart`
+
+`coach_report_providers.dart` exposes a provider that wires a
+`CoachReportBuilder` to the real DAOs and a provider family
+`coachReportProvider(profileId)` returning the built `CoachReport`.
+
+`CoachViewScreen` is a sealed read-only screen:
+
+- It is NOT placed inside the adaptive shell — no bottom nav, no rail.
+- If more than one profile is shared, show a picker of shared profiles
+  (from `sharedProfileIdsProvider`); otherwise go straight to the single
+  shared profile.
+- For the selected profile, render one read-only panel per category in the
+  report's `includedCategories` — no edit, add, or delete controls.
+- An *Export PDF* action: build the PDF via `CoachPdfBuilder` and hand the
+  bytes to the `printing` package's share/layout API.
+- An *Exit coach view* action (app-bar close button) that pops the route.
+
+- [ ] **Step 1: Write the failing widget test**
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+// imports for AppDatabase, DAOs, providers, and CoachViewScreen.
+
+void main() {
+  testWidgets('coach view shows only shared categories and no edit controls',
+      (tester) async {
+    // Seed a profile 'p1' with swim sessions and race times.
+    // Save a CoachShare for 'p1' enabled with ONLY swimSessions shared.
+    // Pump CoachViewScreen for 'p1' inside ProviderScope + MaterialApp.
+    await tester.pumpAndSettle();
+
+    expect(find.text('Swim sessions'), findsOneWidget);
+    expect(find.text('Race times'), findsNothing,
+        reason: 'race times were not shared');
+    expect(find.byIcon(Icons.edit), findsNothing);
+    expect(find.byIcon(Icons.delete), findsNothing);
+  });
+}
+```
+
+Fill in the seeding and pump using the real DAO/provider APIs.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/coach/presentation/coach_view_screen_test.dart`
+Expected: FAIL — screen does not exist.
+
+- [ ] **Step 3: Implement the providers and screen**
+
+Implement `coach_report_providers.dart` and `CoachViewScreen` as described.
+Read-only panels may be small private widgets in the same file. No widget in
+this screen may expose an edit/add/delete affordance.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/coach/presentation/coach_view_screen_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/coach/presentation/screens/coach_view_screen.dart lib/features/coach/presentation/providers/coach_report_providers.dart test/features/coach/presentation/coach_view_screen_test.dart
+git commit -m "feat: add sealed read-only coach view screen (#10)"
+```
+
+---
+
+## Task 12: Routes
+
+**Files:**
+- Modify: `lib/app.dart`
+
+- [ ] **Step 1: Add imports**
+
+In `lib/app.dart`, add with the other feature-screen imports:
+
+```dart
+import 'features/coach/presentation/screens/coach_sharing_settings_screen.dart';
+import 'features/coach/presentation/screens/coach_view_screen.dart';
+```
+
+- [ ] **Step 2: Add top-level routes**
+
+Both coach routes are sealed screens, so they go OUTSIDE the `ShellRoute`,
+alongside `/tempo` and `/stopwatch`. Add inside the top-level `routes:` list
+of `_router`, after the `/settings/sync` route:
+
+```dart
+    GoRoute(
+      path: '/coach',
+      builder: (context, state) => const CoachViewScreen(),
+    ),
+    GoRoute(
+      path: '/coach/sharing/:profileId',
+      builder: (context, state) => CoachSharingSettingsScreen(
+        profileId: state.pathParameters['profileId']!,
+      ),
+    ),
+```
+
+If `CoachViewScreen` requires a profile id rather than choosing one itself,
+pass it the same way as `CoachSharingSettingsScreen`.
+
+- [ ] **Step 3: Verify analysis**
+
+Run: `flutter analyze`
+Expected: no issues.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/app.dart
+git commit -m "feat: register coach mode routes (#10)"
+```
+
+---
+
+## Task 13: Profiles screen integration
+
+**Files:**
+- Modify: `lib/features/profiles/presentation/screens/profiles_screen.dart`
+- Test: `test/features/profiles/profiles_screen_coach_test.dart`
+
+Read `profiles_screen.dart` first to match its card layout and action style.
+
+Add three things:
+
+1. A *Coach sharing* action on each profile card that navigates to
+   `/coach/sharing/<profileId>`.
+2. A *Shared with coach* badge/icon on cards whose profile has active sharing
+   (watch `sharedProfileIdsProvider`).
+3. A *Coach view* entry (app-bar action) that navigates to `/coach`, shown
+   only when `sharedProfileIdsProvider` is non-empty.
+
+- [ ] **Step 1: Write the failing widget test**
+
+```dart
+// Pump ProfilesScreen inside ProviderScope + MaterialApp with a router or a
+// mocked navigator. Seed one profile with active coach sharing via an
+// overridden CoachShareDao.
+// Assert a "Shared with coach" indicator is shown for that profile.
+```
+
+Write a concrete test that seeds a shared profile and asserts the indicator
+appears, and that an unshared profile shows none. Use the override pattern
+from Task 10's test.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/profiles/profiles_screen_coach_test.dart`
+Expected: FAIL — indicator not implemented.
+
+- [ ] **Step 3: Implement the integration**
+
+Add the action, badge, and app-bar entry. Keep edits minimal and follow the
+existing card structure.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/profiles/profiles_screen_coach_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Run the profiles test suite for regressions**
+
+Run: `flutter test test/features/profiles/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/profiles/presentation/screens/profiles_screen.dart test/features/profiles/profiles_screen_coach_test.dart
+git commit -m "feat: surface coach sharing and coach view on the Profiles screen (#10)"
+```
+
+---
+
+## Task 14: Final validation
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Format**
+
+Run: `dart format lib test`
+Expected: files formatted; commit any reformatting if needed.
+
+- [ ] **Step 2: Static analysis**
+
+Run: `flutter analyze`
+Expected: exit 0, no issues.
+
+- [ ] **Step 3: Full test suite**
+
+Run: `flutter test`
+Expected: all tests pass, including the pre-existing suite and every coach
+mode test added by this plan.
+
+- [ ] **Step 4: Commit any fixes**
+
+If Steps 1–3 required corrections:
+
+```bash
+git add -A
+git commit -m "chore: final validation fixes for coach mode (#10)"
+```
+
+If nothing needed fixing, no commit is necessary.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** dependencies (Task 1); `CoachShareCategory` (Task 2);
+  `CoachShare` rules (Task 3); `coach_shares` table + v13 migration (Task 4);
+  `CoachShareDao` persistence (Task 5); providers incl. enable/toggle/revoke
+  (Task 6); `CoachReport` (Task 7); `CoachReportBuilder` with category and
+  profile scoping (Task 8); `CoachPdfBuilder` (Task 9); sharing settings UI
+  (Task 10); sealed coach view + PDF export (Task 11); routes (Task 12);
+  Profiles-screen entry points, badge, review (Task 13); validation (Task 14).
+  Unit/widget/integration tests are embedded throughout per issue #10's
+  acceptance criteria.
+- **Type consistency:** `CoachShare`, `CoachShareCategory`, `CoachReport`,
+  `CoachShareDao`, `CoachReportBuilder`, `CoachPdfBuilder`,
+  `coachShareDaoProvider`, `coachShareControllerProvider`,
+  `sharedProfileIdsProvider` are used consistently across tasks.
+- **Open implementation detail:** Tasks 7 and 8 deliberately defer the exact
+  entity/DAO type names to the implementer, who must read the named source
+  files — those types are existing code, not defined by this plan.
+- **Out of scope, as designed:** remote/cloud delivery, coach write-back, a
+  PIN lock, and multiple named coaches.

--- a/docs/superpowers/specs/2026-05-16-coach-mode-design.md
+++ b/docs/superpowers/specs/2026-05-16-coach-mode-design.md
@@ -1,0 +1,201 @@
+# Coach mode — design
+
+- **Date:** 2026-05-16
+- **Issue:** #10 — Add coach mode for sharing swimmer details
+- **Author:** Paul Snow
+- **Status:** Approved (design); ready for implementation plan
+
+## Summary
+
+Coach mode lets a swimmer share selected details of selected profiles with a
+coach in a controlled, read-only way. It has two delivery paths, both
+offline-first:
+
+1. An on-device, **sealed read-only coach view** the swimmer can hand to a
+   coach in person.
+2. A **PDF export** of a shared profile's shared data the swimmer can send to
+   a remote coach.
+
+Sharing is opt-in per profile and per data category. Nothing is shared until
+the swimmer explicitly enables it.
+
+## Goals
+
+- Per-profile, per-category opt-in sharing, persisted locally.
+- A read-only coach view that exposes only shared data and no editing.
+- A PDF report of a shared profile for remote coaches.
+- Clear visibility of what is currently shared, and a one-action revoke.
+- Preserve the offline-first contract — no network dependency.
+
+## Non-goals
+
+- Remote or cloud delivery of shared data. The PDF file is the bridge to a
+  remote coach until the sync layer gains a live backend.
+- Coach write-back or editing of swimmer data.
+- A PIN or passcode lock on the coach view (the sealed view with an explicit
+  exit is sufficient for this iteration).
+- Multiple named coaches or per-coach identity.
+
+## Decisions
+
+Settled during brainstorming:
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Coach access | On-device coach view **and** PDF export | Covers in-person and remote coaches without a backend. |
+| Export format | PDF | Universally viewable; "official" feel for a coach. |
+| Coach view lock | Sealed read-only screen, explicit exit, no PIN | Meets the read-only requirement without PIN infrastructure. |
+| Category granularity | One opt-in toggle per category, all default off | Matches issue #10's privacy requirements. |
+
+## Architecture
+
+A new feature module `lib/features/coach/`, following the project's
+domain/data/presentation layout.
+
+```
+lib/features/coach/
+├── domain/
+│   ├── entities/
+│   │   ├── coach_share_category.dart   # enum of shareable categories
+│   │   └── coach_share.dart            # per-profile sharing config
+│   └── services/
+│       ├── coach_report_builder.dart   # assembles the shared-data report model
+│       └── coach_pdf_builder.dart      # renders the report model to a PDF
+├── data/
+│   └── coach_share_repository.dart     # wraps CoachShareDao
+└── presentation/
+    ├── providers/
+    │   └── coach_providers.dart
+    ├── screens/
+    │   ├── coach_sharing_settings_screen.dart
+    │   └── coach_view_screen.dart
+    └── widgets/
+        └── (read-only category panels for the coach view)
+```
+
+Plus:
+
+- `lib/database/daos/coach_share_dao.dart` — persistence DAO.
+- Route entries in `lib/app.dart`.
+- `pdf` and `printing` dependencies in `pubspec.yaml`.
+
+### Central report model
+
+`coach_report_builder` assembles a single **report model** for a chosen
+profile: the profile, plus each shared category's data, pulled from the
+existing DAOs (`SwimSessionDao`, `RaceTimeDao`, `PbDao`, `DrylandDao`, and the
+analytics computation). Both the coach view and `coach_pdf_builder` consume
+this one model, so "what is shared" is defined in exactly one place and the
+two outputs cannot diverge.
+
+### Data model
+
+New table `coach_shares`, one row per profile:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `profile_id` | TEXT | Primary key; `REFERENCES profiles(id) ON DELETE CASCADE`. |
+| `enabled` | INTEGER | Master "share with coach" flag (0/1). |
+| `shared_categories` | TEXT | The set of shared categories, stored as a JSON array of category keys — the same pattern already used for `SwimmerProfile.preferredStrokes` (the `preferred_strokes_json` column). |
+
+A profile with no row is not shared. `kDbVersion` bumps **12 → 13**, with a
+matching branch added to `_onUpgrade` in `AppDatabase` and the table created
+in `_onCreate`.
+
+`CoachShareCategory` enum — eight independent categories:
+
+`profileDetails`, `goals`, `notes`, `swimSessions`, `raceTimes`,
+`personalBests`, `analytics`, `dryland`.
+
+Every category defaults to **off**. `notes` and `profileDetails` in
+particular are only ever included when explicitly enabled.
+
+## Features
+
+### Sharing configuration
+
+`coach_sharing_settings_screen` (route `/coach/sharing/:profileId`), reached
+from a **"Coach sharing" action on each profile card** on the Profiles screen.
+
+- A master *Share with coach* switch — toggles `enabled`.
+- A per-category toggle list, shown when sharing is enabled.
+- A plain-language summary of what is currently shared.
+- A *Stop sharing* action that disables sharing for the profile.
+- Notes/personal-detail categories carry a short caution that they are only
+  shared when explicitly switched on.
+
+### Sharing status
+
+Each profile card on the Profiles screen shows a **"Shared with coach"**
+indicator (icon or chip) when that profile has sharing enabled.
+
+### Coach view
+
+`coach_view_screen` (route `/coach`), rendered **outside the adaptive shell**
+— no bottom navigation, no navigation rail. Reached from a *Coach view*
+action on the Profiles screen, which is available only when at least one
+profile has sharing enabled.
+
+- If more than one profile is shared, a picker lists **only shared profiles**.
+- Selecting a profile shows a read-only dashboard: one panel per **shared**
+  category. Unshared categories do not appear at all.
+- An *Export PDF* action for the selected profile.
+- A single explicit *Exit coach view* action returns to normal mode.
+- No edit, add, or delete controls anywhere in this view.
+
+### PDF export
+
+`coach_pdf_builder` renders the report model to a `pdf.Document` containing
+only the shared categories, headed with the swimmer's name and the list of
+included categories. The `printing` package handles sharing/saving the file.
+Export is available from the coach view and produces the same data the view
+shows.
+
+## Error handling
+
+- A profile whose sharing is revoked mid-session drops out of the coach-view
+  picker; an in-progress export for it is guarded against the revoked state.
+- Empty categories (for example a profile with no race times) render a
+  "No data" placeholder rather than an error.
+- A PDF generation or share failure surfaces a clear message and does not
+  crash the app.
+- Deleting a profile cascades to remove its `coach_shares` row.
+
+## Testing
+
+Per issue #10's acceptance criteria:
+
+- **Unit tests** — `CoachShareCategory` / `CoachShare` rules; `coach_report_builder`
+  includes only the enabled categories and only the selected profile's data
+  (profile scoping); `coach_pdf_builder` produces a document for a populated
+  report.
+- **Widget tests** — enabling sharing, toggling individual categories,
+  reviewing the shared-categories summary, and disabling sharing; the coach
+  view renders only shared categories and exposes no edit affordances.
+- **Integration tests** — `CoachShareDao` round-trip persistence of the
+  sharing configuration, and cascade deletion when the owning profile is
+  removed.
+
+## Acceptance criteria (issue #10)
+
+- [x] Enable coach sharing from profile management — *Sharing configuration*.
+- [x] Select profiles and data categories to share — *Sharing configuration*.
+- [x] Shared data stays scoped to the selected profile — *Central report
+  model* + scoping unit tests.
+- [x] Review what is currently shared — *Sharing configuration* summary +
+  Profiles-screen indicator.
+- [x] Revoke sharing — *Stop sharing* action.
+- [x] UI distinguishes coach/read-only from editing — *Coach view* (sealed,
+  no edit controls).
+- [x] Unit tests for sharing rules and profile scoping — *Testing*.
+- [x] Widget tests for enable/review/disable — *Testing*.
+- [x] Integration tests for persistence — *Testing*.
+
+## Risks
+
+- **New dependencies** — `pdf` and `printing` are added to the project. Both
+  are widely used Flutter packages, but they are the first such additions for
+  this feature; the implementation plan pins versions and the build is
+  verified after they are added.
+- **Schema migration** — the v12 → v13 migration must create `coach_shares`
+  without disturbing existing data; covered by an integration/migration test.

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -19,6 +19,8 @@ import 'features/race/presentation/screens/qualification_standards_screen.dart';
 import 'features/race/presentation/screens/race_times_screen.dart';
 import 'features/analytics/presentation/screens/analytics_screen.dart';
 import 'features/dryland/presentation/screens/dryland_screen.dart';
+import 'features/coach/presentation/screens/coach_sharing_settings_screen.dart';
+import 'features/coach/presentation/screens/coach_view_screen.dart';
 import 'features/settings/presentation/screens/sync_settings_screen.dart';
 import 'features/profiles/presentation/providers/profile_providers.dart';
 
@@ -106,6 +108,16 @@ final _router = GoRouter(
     GoRoute(
       path: '/settings/sync',
       builder: (context, state) => const SyncSettingsScreen(),
+    ),
+    GoRoute(
+      path: '/coach',
+      builder: (context, state) => const CoachViewScreen(),
+    ),
+    GoRoute(
+      path: '/coach/sharing/:profileId',
+      builder: (context, state) => CoachSharingSettingsScreen(
+        profileId: state.pathParameters['profileId']!,
+      ),
     ),
   ],
 );

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -10,7 +10,7 @@ const List<String> kStrokes = [
 const List<int> kStandardDistances = [25, 50, 100, 200, 400, 800, 1500];
 
 const String kAppName = 'repSwim';
-const int kDbVersion = 12;
+const int kDbVersion = 13;
 const String kDefaultProfileId = 'local-default-profile';
 const String kDefaultProfileName = 'Default Swimmer';
 const String kSelectedProfileIdSetting = 'selected_profile_id';

--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -127,6 +127,7 @@ class AppDatabase {
     await _createRaceTimesTable(db);
     await _createQualificationStandardsTable(db);
     await _createMeetQualificationStandardsTable(db);
+    await _createCoachSharesTable(db);
   }
 
   Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
@@ -184,6 +185,9 @@ class AppDatabase {
     }
     if (oldVersion < 12) {
       await _createTempoTables(db);
+    }
+    if (oldVersion < 13) {
+      await _createCoachSharesTable(db);
     }
   }
 
@@ -483,6 +487,19 @@ class AppDatabase {
         stroke,
         distance,
         course_type
+      )
+    ''');
+  }
+
+  Future<void> _createCoachSharesTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS coach_shares (
+        profile_id TEXT PRIMARY KEY,
+        enabled INTEGER NOT NULL DEFAULT 0,
+        shared_categories_json TEXT NOT NULL DEFAULT '[]',
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY (profile_id)
+          REFERENCES swimmer_profiles(id) ON DELETE CASCADE
       )
     ''');
   }

--- a/lib/database/daos/coach_share_dao.dart
+++ b/lib/database/daos/coach_share_dao.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+
+import 'package:sqflite/sqflite.dart';
+
+import '../../features/coach/domain/entities/coach_share.dart';
+import '../../features/coach/domain/entities/coach_share_category.dart';
+import '../app_database.dart';
+
+/// Persistence for per-profile coach-sharing configuration.
+class CoachShareDao {
+  const CoachShareDao(this._db);
+
+  final AppDatabase _db;
+
+  /// Returns the sharing configuration for [profileId]. A profile with no
+  /// stored row yields a disabled [CoachShare] with no categories.
+  Future<CoachShare> getForProfile(String profileId) async {
+    final db = await _db.database;
+    final rows = await db.query(
+      'coach_shares',
+      where: 'profile_id = ?',
+      whereArgs: [profileId],
+      limit: 1,
+    );
+    if (rows.isEmpty) return CoachShare(profileId: profileId);
+    return _fromRow(rows.first);
+  }
+
+  /// Inserts or replaces the configuration for the share's profile.
+  Future<void> save(CoachShare share) async {
+    final db = await _db.database;
+    await db.insert(
+      'coach_shares',
+      {
+        'profile_id': share.profileId,
+        'enabled': share.enabled ? 1 : 0,
+        'shared_categories_json': jsonEncode(
+          share.sharedCategories.map((c) => c.key).toList(),
+        ),
+        'updated_at': DateTime.now().toUtc().millisecondsSinceEpoch,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  /// Removes any stored configuration for [profileId].
+  Future<void> delete(String profileId) async {
+    final db = await _db.database;
+    await db.delete(
+      'coach_shares',
+      where: 'profile_id = ?',
+      whereArgs: [profileId],
+    );
+  }
+
+  /// IDs of profiles that currently share at least one category.
+  Future<List<String>> getSharedProfileIds() async {
+    final db = await _db.database;
+    final rows = await db.query('coach_shares', where: 'enabled = 1');
+    return rows
+        .map(_fromRow)
+        .where((share) => share.hasActiveSharing)
+        .map((share) => share.profileId)
+        .toList();
+  }
+
+  CoachShare _fromRow(Map<String, Object?> row) {
+    return CoachShare(
+      profileId: row['profile_id'] as String,
+      enabled: (row['enabled'] as int) == 1,
+      sharedCategories: _decodeCategories(
+        row['shared_categories_json'] as String?,
+      ),
+    );
+  }
+
+  Set<CoachShareCategory> _decodeCategories(String? value) {
+    if (value == null || value.isEmpty) return const {};
+    try {
+      final decoded = jsonDecode(value);
+      if (decoded is! List) return const {};
+      return decoded
+          .whereType<String>()
+          .map(CoachShareCategory.fromKey)
+          .whereType<CoachShareCategory>()
+          .toSet();
+    } on FormatException {
+      return const {};
+    }
+  }
+}

--- a/lib/features/coach/domain/entities/coach_report.dart
+++ b/lib/features/coach/domain/entities/coach_report.dart
@@ -1,0 +1,53 @@
+import '../../../analytics/presentation/providers/analytics_providers.dart';
+import '../../../dryland/domain/entities/dryland_workout.dart';
+import '../../../pb/domain/entities/personal_best.dart';
+import '../../../profiles/domain/entities/swimmer_profile.dart';
+import '../../../race/domain/entities/race_time.dart';
+import '../../../swim/domain/entities/swim_session.dart';
+import 'coach_share_category.dart';
+
+/// An immutable snapshot of a swimmer's shared data assembled for a coach.
+///
+/// Fields backed by data are nullable: a null value indicates that category
+/// was not included in this report. The [includedCategories] set is the
+/// authoritative record of what was requested; use [includes] to query it.
+///
+/// [profileDetails], [goals], and [notes] carry no dedicated field because
+/// they are already present on [profile]; they are tracked only via
+/// [includedCategories].
+class CoachReport {
+  const CoachReport({
+    required this.profile,
+    required this.includedCategories,
+    this.swimSessions,
+    this.raceTimes,
+    this.personalBests,
+    this.drylandWorkouts,
+    this.analytics,
+  });
+
+  /// The swimmer profile whose data this report covers.
+  final SwimmerProfile profile;
+
+  /// The set of categories that were active when this report was built.
+  final Set<CoachShareCategory> includedCategories;
+
+  /// Swim sessions shared with the coach, or null if not included.
+  final List<SwimSession>? swimSessions;
+
+  /// Race times shared with the coach, or null if not included.
+  final List<RaceTime>? raceTimes;
+
+  /// Personal bests shared with the coach, or null if not included.
+  final List<PersonalBest>? personalBests;
+
+  /// Dryland workouts shared with the coach, or null if not included.
+  final List<DrylandWorkout>? drylandWorkouts;
+
+  /// Computed analytics shared with the coach, or null if not included.
+  final AnalyticsData? analytics;
+
+  /// Returns true when [category] is part of this report.
+  bool includes(CoachShareCategory category) =>
+      includedCategories.contains(category);
+}

--- a/lib/features/coach/domain/entities/coach_share.dart
+++ b/lib/features/coach/domain/entities/coach_share.dart
@@ -1,0 +1,47 @@
+import 'coach_share_category.dart';
+
+/// The coach-sharing configuration for a single swimmer profile.
+///
+/// Sharing is opt-in: nothing is shared unless [enabled] is true *and* the
+/// category is present in [sharedCategories].
+class CoachShare {
+  const CoachShare({
+    required this.profileId,
+    this.enabled = false,
+    this.sharedCategories = const {},
+  });
+
+  final String profileId;
+  final bool enabled;
+  final Set<CoachShareCategory> sharedCategories;
+
+  /// Whether [category] is actually shared (master flag on and ticked).
+  bool isShared(CoachShareCategory category) =>
+      enabled && sharedCategories.contains(category);
+
+  /// The categories actually shared right now — empty when [enabled] is false.
+  Set<CoachShareCategory> get activeCategories =>
+      enabled ? Set.unmodifiable(sharedCategories) : const {};
+
+  /// True when this profile shares at least one category with a coach.
+  bool get hasActiveSharing => enabled && sharedCategories.isNotEmpty;
+
+  CoachShare withCategory(CoachShareCategory category) => copyWith(
+        sharedCategories: {...sharedCategories, category},
+      );
+
+  CoachShare withoutCategory(CoachShareCategory category) => copyWith(
+        sharedCategories: {...sharedCategories}..remove(category),
+      );
+
+  CoachShare copyWith({
+    bool? enabled,
+    Set<CoachShareCategory>? sharedCategories,
+  }) {
+    return CoachShare(
+      profileId: profileId,
+      enabled: enabled ?? this.enabled,
+      sharedCategories: sharedCategories ?? this.sharedCategories,
+    );
+  }
+}

--- a/lib/features/coach/domain/entities/coach_share_category.dart
+++ b/lib/features/coach/domain/entities/coach_share_category.dart
@@ -1,0 +1,27 @@
+/// A category of swimmer data that can be shared with a coach.
+///
+/// [key] is the stable identifier persisted in the database; [label] is the
+/// human-readable name shown in the UI.
+enum CoachShareCategory {
+  profileDetails('profile_details', 'Profile details'),
+  goals('goals', 'Goals'),
+  notes('notes', 'Notes'),
+  swimSessions('swim_sessions', 'Swim sessions'),
+  raceTimes('race_times', 'Race times'),
+  personalBests('personal_bests', 'Personal bests'),
+  analytics('analytics', 'Analytics'),
+  dryland('dryland', 'Dryland training');
+
+  const CoachShareCategory(this.key, this.label);
+
+  final String key;
+  final String label;
+
+  /// Returns the category with the given [key], or null if none matches.
+  static CoachShareCategory? fromKey(String key) {
+    for (final category in values) {
+      if (category.key == key) return category;
+    }
+    return null;
+  }
+}

--- a/lib/features/coach/domain/services/coach_pdf_builder.dart
+++ b/lib/features/coach/domain/services/coach_pdf_builder.dart
@@ -1,0 +1,236 @@
+import 'dart:typed_data';
+
+import 'package:pdf/widgets.dart' as pw;
+
+import '../../../analytics/presentation/providers/analytics_providers.dart';
+import '../../../dryland/domain/entities/dryland_workout.dart';
+import '../../../pb/domain/entities/personal_best.dart';
+import '../../../race/domain/entities/race_time.dart';
+import '../../../swim/domain/entities/swim_session.dart';
+import '../entities/coach_report.dart';
+import '../entities/coach_share_category.dart';
+
+/// Builds a PDF document from a [CoachReport].
+///
+/// The resulting bytes begin with the standard `%PDF` magic header and
+/// contain one section per included category.  Categories whose backing data
+/// list is empty render a "No data" line rather than throwing.
+class CoachPdfBuilder {
+  const CoachPdfBuilder();
+
+  /// Assembles the PDF and returns the raw bytes.
+  Future<Uint8List> build(CoachReport report) async {
+    final doc = pw.Document();
+
+    doc.addPage(
+      pw.MultiPage(
+        build: (pw.Context context) => [
+          _buildHeader(report),
+          pw.SizedBox(height: 12),
+          ..._buildSections(report),
+        ],
+      ),
+    );
+
+    return doc.save();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Header
+  // ---------------------------------------------------------------------------
+
+  pw.Widget _buildHeader(CoachReport report) {
+    final categoryLabels =
+        report.includedCategories.map((c) => c.label).join(', ');
+
+    return pw.Column(
+      crossAxisAlignment: pw.CrossAxisAlignment.start,
+      children: [
+        pw.Text(
+          report.profile.displayName,
+          style: pw.TextStyle(fontSize: 20, fontWeight: pw.FontWeight.bold),
+        ),
+        pw.SizedBox(height: 4),
+        pw.Text(
+          'Included categories: $categoryLabels',
+          style: const pw.TextStyle(fontSize: 10),
+        ),
+        pw.Divider(),
+      ],
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Sections — one per included category
+  // ---------------------------------------------------------------------------
+
+  List<pw.Widget> _buildSections(CoachReport report) {
+    final widgets = <pw.Widget>[];
+
+    for (final category in report.includedCategories) {
+      widgets
+        ..add(_sectionHeading(category.label))
+        ..addAll(_sectionBody(category, report))
+        ..add(pw.SizedBox(height: 10));
+    }
+
+    return widgets;
+  }
+
+  pw.Widget _sectionHeading(String title) {
+    return pw.Text(
+      title,
+      style: pw.TextStyle(fontSize: 14, fontWeight: pw.FontWeight.bold),
+    );
+  }
+
+  List<pw.Widget> _sectionBody(
+    CoachShareCategory category,
+    CoachReport report,
+  ) {
+    switch (category) {
+      case CoachShareCategory.profileDetails:
+        return _profileDetailsSection(report);
+      case CoachShareCategory.goals:
+        return _goalsSection(report);
+      case CoachShareCategory.notes:
+        return _notesSection(report);
+      case CoachShareCategory.swimSessions:
+        return _swimSessionsSection(report.swimSessions);
+      case CoachShareCategory.raceTimes:
+        return _raceTimesSection(report.raceTimes);
+      case CoachShareCategory.personalBests:
+        return _personalBestsSection(report.personalBests);
+      case CoachShareCategory.dryland:
+        return _drylandSection(report.drylandWorkouts);
+      case CoachShareCategory.analytics:
+        return _analyticsSection(report.analytics);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Profile-backed category sections
+  // ---------------------------------------------------------------------------
+
+  List<pw.Widget> _profileDetailsSection(CoachReport report) {
+    final profile = report.profile;
+    final rows = <String>[
+      'Name: ${profile.displayName}',
+      if (profile.clubName != null) 'Club: ${profile.clubName}',
+      if (profile.primaryEvents != null) 'Events: ${profile.primaryEvents}',
+      'Pool length: ${profile.preferredPoolLengthMeters} m',
+      if (profile.preferredStrokes.isNotEmpty)
+        'Preferred strokes: ${profile.preferredStrokes.join(', ')}',
+    ];
+    return rows.map((r) => pw.Text(r)).toList();
+  }
+
+  List<pw.Widget> _goalsSection(CoachReport report) {
+    final goals = report.profile.goals;
+    if (goals == null || goals.isEmpty) {
+      return [pw.Text('No data')];
+    }
+    return [pw.Text(goals)];
+  }
+
+  List<pw.Widget> _notesSection(CoachReport report) {
+    final notes = report.profile.notes;
+    if (notes == null || notes.isEmpty) {
+      return [pw.Text('No data')];
+    }
+    return [pw.Text(notes)];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Data-backed category sections
+  // ---------------------------------------------------------------------------
+
+  List<pw.Widget> _swimSessionsSection(List<SwimSession>? sessions) {
+    if (sessions == null || sessions.isEmpty) {
+      return [pw.Text('No data')];
+    }
+    return sessions.map((s) {
+      final date = _formatDate(s.date);
+      final mins = s.totalTime.inMinutes;
+      final secs = s.totalTime.inSeconds % 60;
+      return pw.Text(
+        '$date — ${s.stroke} ${s.totalDistance} m  '
+        '${mins}m ${secs}s',
+      );
+    }).toList();
+  }
+
+  List<pw.Widget> _raceTimesSection(List<RaceTime>? raceTimes) {
+    if (raceTimes == null || raceTimes.isEmpty) {
+      return [pw.Text('No data')];
+    }
+    return raceTimes.map((r) {
+      final date = _formatDate(r.eventDate);
+      final mins = r.time.inMinutes;
+      final secs = r.time.inSeconds % 60;
+      final ms = r.time.inMilliseconds % 1000;
+      return pw.Text(
+        '$date — ${r.raceName}  ${r.distance} m ${r.stroke}  '
+        '$mins:${secs.toString().padLeft(2, '0')}.${ms.toString().padLeft(3, '0')}',
+      );
+    }).toList();
+  }
+
+  List<pw.Widget> _personalBestsSection(List<PersonalBest>? pbs) {
+    if (pbs == null || pbs.isEmpty) {
+      return [pw.Text('No data')];
+    }
+    return pbs.map((pb) {
+      final date = _formatDate(pb.achievedAt);
+      final mins = pb.bestTime.inMinutes;
+      final secs = pb.bestTime.inSeconds % 60;
+      final ms = pb.bestTime.inMilliseconds % 1000;
+      return pw.Text(
+        '${pb.stroke} ${pb.distance} m  '
+        '$mins:${secs.toString().padLeft(2, '0')}.${ms.toString().padLeft(3, '0')}  '
+        '($date)',
+      );
+    }).toList();
+  }
+
+  List<pw.Widget> _drylandSection(List<DrylandWorkout>? workouts) {
+    if (workouts == null || workouts.isEmpty) {
+      return [pw.Text('No data')];
+    }
+    return workouts.map((w) {
+      final date = _formatDate(w.date);
+      return pw.Text(
+        '$date — ${w.exercises.length} exercise(s)',
+      );
+    }).toList();
+  }
+
+  List<pw.Widget> _analyticsSection(AnalyticsData? analytics) {
+    if (analytics == null) {
+      return [pw.Text('No data')];
+    }
+    final paceMin = analytics.averagePacePerHundred.inMinutes;
+    final paceSec = analytics.averagePacePerHundred.inSeconds % 60;
+    return [
+      pw.Text('Total sessions: ${analytics.totalSessions}'),
+      pw.Text('Total distance: ${analytics.totalDistanceMeters} m'),
+      pw.Text(
+        'Average pace per 100 m: '
+        '$paceMin:${paceSec.toString().padLeft(2, '0')}',
+      ),
+      pw.Text('Consistency score: ${analytics.consistencyScore}'),
+    ];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /// Formats a [DateTime] as `YYYY-MM-DD`.
+  String _formatDate(DateTime date) {
+    final y = date.year.toString().padLeft(4, '0');
+    final m = date.month.toString().padLeft(2, '0');
+    final d = date.day.toString().padLeft(2, '0');
+    return '$y-$m-$d';
+  }
+}

--- a/lib/features/coach/domain/services/coach_report_builder.dart
+++ b/lib/features/coach/domain/services/coach_report_builder.dart
@@ -1,0 +1,92 @@
+import '../../../../database/daos/dryland_dao.dart';
+import '../../../../database/daos/pb_dao.dart';
+import '../../../../database/daos/profile_dao.dart';
+import '../../../../database/daos/race_time_dao.dart';
+import '../../../../database/daos/swim_session_dao.dart';
+import '../../../analytics/presentation/providers/analytics_providers.dart';
+import '../../../dryland/domain/entities/dryland_workout.dart';
+import '../../../pb/domain/entities/personal_best.dart';
+import '../../../profiles/domain/entities/swimmer_profile.dart';
+import '../../../race/domain/entities/race_time.dart';
+import '../../../swim/domain/entities/swim_session.dart';
+import '../entities/coach_report.dart';
+import '../entities/coach_share.dart';
+import '../entities/coach_share_category.dart';
+
+/// Assembles a [CoachReport] for a given profile by loading only the data
+/// categories that the [CoachShare] has enabled.
+///
+/// Every DAO call is scoped to [profileId] so no cross-profile data leaks.
+class CoachReportBuilder {
+  const CoachReportBuilder({
+    required this.profileDao,
+    required this.sessionDao,
+    required this.raceTimeDao,
+    required this.pbDao,
+    required this.drylandDao,
+  });
+
+  final ProfileDao profileDao;
+  final SwimSessionDao sessionDao;
+  final RaceTimeDao raceTimeDao;
+  final PbDao pbDao;
+  final DrylandDao drylandDao;
+
+  /// Builds a [CoachReport] for [profileId] respecting the [share] settings.
+  ///
+  /// Only categories present in [share.activeCategories] are loaded.
+  /// Returns an empty [CoachReport] (no data fields populated) when [share]
+  /// is disabled.
+  Future<CoachReport> build(String profileId, CoachShare share) async {
+    // Resolve the swimmer profile; fall back to the default if not found.
+    final allProfiles = await profileDao.getAll();
+    final SwimmerProfile profile = allProfiles.firstWhere(
+      (p) => p.id == profileId,
+      orElse: () => SwimmerProfile.defaultProfile,
+    );
+
+    final categories = share.activeCategories;
+
+    // Load data for each active category, keeping other fields null.
+    List<SwimSession>? swimSessions;
+    List<RaceTime>? raceTimes;
+    List<PersonalBest>? personalBests;
+    List<DrylandWorkout>? drylandWorkouts;
+    AnalyticsData? analytics;
+
+    if (categories.contains(CoachShareCategory.swimSessions)) {
+      swimSessions = await sessionDao.getAllSessions(profileId);
+    }
+
+    if (categories.contains(CoachShareCategory.raceTimes)) {
+      raceTimes = await raceTimeDao.getAll(profileId);
+    }
+
+    if (categories.contains(CoachShareCategory.personalBests)) {
+      personalBests = await pbDao.getAll(profileId);
+    }
+
+    if (categories.contains(CoachShareCategory.dryland)) {
+      drylandWorkouts = await drylandDao.getAll(profileId);
+    }
+
+    if (categories.contains(CoachShareCategory.analytics)) {
+      // Ensure the sessions and PBs used for analytics are scoped to this
+      // profile, loading them here if they were not already requested.
+      final sessions =
+          swimSessions ?? await sessionDao.getAllSessions(profileId);
+      final pbs = personalBests ?? await pbDao.getAll(profileId);
+      analytics = computeAnalytics(sessions, pbs);
+    }
+
+    return CoachReport(
+      profile: profile,
+      includedCategories: categories,
+      swimSessions: swimSessions,
+      raceTimes: raceTimes,
+      personalBests: personalBests,
+      drylandWorkouts: drylandWorkouts,
+      analytics: analytics,
+    );
+  }
+}

--- a/lib/features/coach/presentation/providers/coach_providers.dart
+++ b/lib/features/coach/presentation/providers/coach_providers.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../database/app_database.dart';
+import '../../../../database/daos/coach_share_dao.dart';
+import '../../domain/entities/coach_share.dart';
+import '../../domain/entities/coach_share_category.dart';
+
+/// DAO for coach-sharing configuration.
+final coachShareDaoProvider = Provider<CoachShareDao>((ref) {
+  return CoachShareDao(AppDatabase.instance);
+});
+
+/// IDs of profiles that currently share data with a coach.
+final sharedProfileIdsProvider = FutureProvider<List<String>>((ref) {
+  return ref.watch(coachShareDaoProvider).getSharedProfileIds();
+});
+
+/// Editable coach-sharing state for a single profile, keyed by profile id.
+final coachShareControllerProvider =
+    AsyncNotifierProvider.family<CoachShareController, CoachShare, String>(
+        CoachShareController.new);
+
+class CoachShareController extends FamilyAsyncNotifier<CoachShare, String> {
+  @override
+  Future<CoachShare> build(String profileId) {
+    return ref.read(coachShareDaoProvider).getForProfile(profileId);
+  }
+
+  Future<void> _persist(CoachShare share) async {
+    await ref.read(coachShareDaoProvider).save(share);
+    state = AsyncData(share);
+    ref.invalidate(sharedProfileIdsProvider);
+  }
+
+  /// Turns the master "share with coach" flag on or off.
+  Future<void> setEnabled(bool enabled) async {
+    final current = state.value ?? CoachShare(profileId: arg);
+    await _persist(current.copyWith(enabled: enabled));
+  }
+
+  /// Adds or removes a single shared category.
+  Future<void> setCategory(CoachShareCategory category, bool shared) async {
+    final current = state.value ?? CoachShare(profileId: arg);
+    await _persist(
+      shared
+          ? current.withCategory(category)
+          : current.withoutCategory(category),
+    );
+  }
+
+  /// Disables all sharing for this profile.
+  Future<void> stopSharing() async {
+    final current = state.value ?? CoachShare(profileId: arg);
+    await _persist(current.copyWith(enabled: false));
+  }
+}

--- a/lib/features/coach/presentation/providers/coach_report_providers.dart
+++ b/lib/features/coach/presentation/providers/coach_report_providers.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../profiles/presentation/providers/profile_providers.dart';
+import '../../../race/presentation/providers/race_time_providers.dart';
+import '../../../swim/presentation/providers/swim_providers.dart';
+import '../../domain/entities/coach_report.dart';
+import '../../domain/services/coach_report_builder.dart';
+import 'coach_providers.dart';
+
+/// Wires [CoachReportBuilder] to the real DAOs.
+final coachReportBuilderProvider = Provider<CoachReportBuilder>((ref) {
+  return CoachReportBuilder(
+    profileDao: ref.read(profileDaoProvider),
+    sessionDao: ref.read(swimSessionDaoProvider),
+    raceTimeDao: ref.read(raceTimeDaoProvider),
+    pbDao: ref.read(pbDaoProvider),
+    drylandDao: ref.read(drylandDaoProvider),
+  );
+});
+
+/// Builds a [CoachReport] for the given profile id.
+///
+/// Reads the profile's [CoachShare] from the DAO and assembles the report via
+/// [CoachReportBuilder].
+final coachReportProvider =
+    FutureProvider.family<CoachReport, String>((ref, profileId) async {
+  final share = await ref.read(coachShareDaoProvider).getForProfile(profileId);
+  final builder = ref.read(coachReportBuilderProvider);
+  return builder.build(profileId, share);
+});

--- a/lib/features/coach/presentation/providers/coach_report_providers.dart
+++ b/lib/features/coach/presentation/providers/coach_report_providers.dart
@@ -21,9 +21,11 @@ final coachReportBuilderProvider = Provider<CoachReportBuilder>((ref) {
 /// Builds a [CoachReport] for the given profile id.
 ///
 /// Reads the profile's [CoachShare] from the DAO and assembles the report via
-/// [CoachReportBuilder].
-final coachReportProvider =
-    FutureProvider.family<CoachReport, String>((ref, profileId) async {
+/// [CoachReportBuilder].  autoDispose ensures a fresh report is built every
+/// time the coach view is opened, preventing stale data after sharing settings
+/// change.
+final coachReportProvider = FutureProvider.autoDispose
+    .family<CoachReport, String>((ref, profileId) async {
   final share = await ref.read(coachShareDaoProvider).getForProfile(profileId);
   final builder = ref.read(coachReportBuilderProvider);
   return builder.build(profileId, share);

--- a/lib/features/coach/presentation/screens/coach_sharing_settings_screen.dart
+++ b/lib/features/coach/presentation/screens/coach_sharing_settings_screen.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entities/coach_share_category.dart';
+import '../providers/coach_providers.dart';
+
+/// Settings screen that lets a swimmer configure what data is shared with a
+/// coach.
+class CoachSharingSettingsScreen extends ConsumerWidget {
+  const CoachSharingSettingsScreen({required this.profileId, super.key});
+
+  final String profileId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final shareAsync = ref.watch(coachShareControllerProvider(profileId));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Coach sharing')),
+      body: shareAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (err, _) => Center(child: Text('Error: $err')),
+        data: (share) {
+          final controller =
+              ref.read(coachShareControllerProvider(profileId).notifier);
+
+          final categoryTiles = CoachShareCategory.values
+              .map(
+                (category) => SwitchListTile(
+                  title: Text(category.label),
+                  value: share.sharedCategories.contains(category),
+                  onChanged: (value) => controller.setCategory(category, value),
+                ),
+              )
+              .toList();
+
+          final sharedLabels = share.sharedCategories.isEmpty
+              ? 'Nothing shared yet'
+              : share.sharedCategories.map((c) => c.label).join(', ');
+
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              SwitchListTile(
+                title: const Text('Share with coach'),
+                value: share.enabled,
+                onChanged: controller.setEnabled,
+              ),
+              if (share.enabled) ...[
+                ...categoryTiles,
+                const SizedBox(height: 8),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Text(
+                    'Notes and personal details are shared only when their '
+                    'switches are on.',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Text('Sharing: $sharedLabels'),
+                ),
+                const SizedBox(height: 16),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: OutlinedButton(
+                    onPressed: controller.stopSharing,
+                    child: const Text('Stop sharing'),
+                  ),
+                ),
+              ],
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/coach/presentation/screens/coach_view_screen.dart
+++ b/lib/features/coach/presentation/screens/coach_view_screen.dart
@@ -1,0 +1,355 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:printing/printing.dart';
+
+import '../../domain/entities/coach_report.dart';
+import '../../domain/entities/coach_share_category.dart';
+import '../../domain/services/coach_pdf_builder.dart';
+import '../providers/coach_providers.dart';
+import '../providers/coach_report_providers.dart';
+
+/// A sealed, read-only view of the data shared with a coach.
+///
+/// The screen contains no edit, add or delete affordances.  A swimmer selects
+/// which profile to view when more than one profile is shared, and can export
+/// the report to PDF via the app-bar action.
+class CoachViewScreen extends ConsumerStatefulWidget {
+  const CoachViewScreen({super.key});
+
+  @override
+  ConsumerState<CoachViewScreen> createState() => _CoachViewScreenState();
+}
+
+class _CoachViewScreenState extends ConsumerState<CoachViewScreen> {
+  /// The profile id currently selected for display, or null when the picker
+  /// has not yet been resolved (zero or multiple shared profiles).
+  String? _selectedProfileId;
+
+  @override
+  Widget build(BuildContext context) {
+    final sharedAsync = ref.watch(sharedProfileIdsProvider);
+
+    return sharedAsync.when(
+      loading: () => Scaffold(
+        appBar: AppBar(title: const Text('Coach view')),
+        body: const Center(child: CircularProgressIndicator()),
+      ),
+      error: (err, _) => Scaffold(
+        appBar: AppBar(title: const Text('Coach view')),
+        body: Center(child: Text('Error: $err')),
+      ),
+      data: (ids) {
+        if (ids.isEmpty) {
+          return Scaffold(
+            appBar: _buildAppBar(context, null),
+            body: const Center(
+              child: Text('No profiles are shared with a coach'),
+            ),
+          );
+        }
+
+        if (ids.length == 1) {
+          return _reportScaffold(context, ids.first);
+        }
+
+        // Multiple profiles: show a picker unless one is already selected.
+        final selected = _selectedProfileId;
+        if (selected != null && ids.contains(selected)) {
+          return _reportScaffold(context, selected);
+        }
+
+        return Scaffold(
+          appBar: _buildAppBar(context, null),
+          body: ListView.builder(
+            itemCount: ids.length,
+            itemBuilder: (context, index) {
+              final id = ids[index];
+              return ListTile(
+                title: Text(id),
+                onTap: () => setState(() => _selectedProfileId = id),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Report scaffold
+  // ---------------------------------------------------------------------------
+
+  Widget _reportScaffold(BuildContext context, String profileId) {
+    final reportAsync = ref.watch(coachReportProvider(profileId));
+
+    return reportAsync.when(
+      loading: () => Scaffold(
+        appBar: _buildAppBar(context, null),
+        body: const Center(child: CircularProgressIndicator()),
+      ),
+      error: (err, _) => Scaffold(
+        appBar: _buildAppBar(context, null),
+        body: Center(child: Text('Error: $err')),
+      ),
+      data: (report) => Scaffold(
+        appBar: _buildAppBar(context, report),
+        body: _ReportBody(report: report),
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // App bar
+  // ---------------------------------------------------------------------------
+
+  AppBar _buildAppBar(BuildContext context, CoachReport? report) {
+    return AppBar(
+      title: const Text('Coach view'),
+      leading: IconButton(
+        icon: const Icon(Icons.close),
+        tooltip: 'Exit coach view',
+        onPressed: () => Navigator.of(context).maybePop(),
+      ),
+      actions: [
+        if (report != null)
+          IconButton(
+            icon: const Icon(Icons.picture_as_pdf),
+            tooltip: 'Export PDF',
+            onPressed: () => _exportPdf(report),
+          ),
+      ],
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // PDF export
+  // ---------------------------------------------------------------------------
+
+  Future<void> _exportPdf(CoachReport report) async {
+    final Uint8List bytes = await const CoachPdfBuilder().build(report);
+    await Printing.sharePdf(
+      bytes: bytes,
+      filename: '${report.profile.displayName}_coach_report.pdf',
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Read-only report body
+// ---------------------------------------------------------------------------
+
+/// Renders one read-only section per category included in [report].
+///
+/// Categories not present in [report.includedCategories] produce no widget.
+class _ReportBody extends StatelessWidget {
+  const _ReportBody({required this.report});
+
+  final CoachReport report;
+
+  @override
+  Widget build(BuildContext context) {
+    final sections = <Widget>[];
+
+    for (final category in CoachShareCategory.values) {
+      if (!report.includes(category)) continue;
+      sections.add(_CategoryPanel(category: category, report: report));
+    }
+
+    if (sections.isEmpty) {
+      return const Center(child: Text('No data shared'));
+    }
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: sections,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Single category panel (private, read-only)
+// ---------------------------------------------------------------------------
+
+class _CategoryPanel extends StatelessWidget {
+  const _CategoryPanel({required this.category, required this.report});
+
+  final CoachShareCategory category;
+  final CoachReport report;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(category.label, style: theme.textTheme.titleMedium),
+        const SizedBox(height: 4),
+        _body(context),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+
+  Widget _body(BuildContext context) {
+    switch (category) {
+      case CoachShareCategory.profileDetails:
+        return _ProfileDetailsBody(report: report);
+      case CoachShareCategory.goals:
+        return _TextBody(text: report.profile.goals);
+      case CoachShareCategory.notes:
+        return _TextBody(text: report.profile.notes);
+      case CoachShareCategory.swimSessions:
+        return _SwimSessionsBody(sessions: report.swimSessions);
+      case CoachShareCategory.raceTimes:
+        return _RaceTimesBody(raceTimes: report.raceTimes);
+      case CoachShareCategory.personalBests:
+        return _PersonalBestsBody(pbs: report.personalBests);
+      case CoachShareCategory.dryland:
+        return _DrylandBody(workouts: report.drylandWorkouts);
+      case CoachShareCategory.analytics:
+        return _AnalyticsBody(analytics: report.analytics);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-category body widgets (private, read-only)
+// ---------------------------------------------------------------------------
+
+class _TextBody extends StatelessWidget {
+  const _TextBody({required this.text});
+
+  final String? text;
+
+  @override
+  Widget build(BuildContext context) {
+    if (text == null || text!.isEmpty) {
+      return const Text('No data');
+    }
+    return Text(text!);
+  }
+}
+
+class _ProfileDetailsBody extends StatelessWidget {
+  const _ProfileDetailsBody({required this.report});
+
+  final CoachReport report;
+
+  @override
+  Widget build(BuildContext context) {
+    final p = report.profile;
+    final rows = <String>[
+      'Name: ${p.displayName}',
+      if (p.clubName != null) 'Club: ${p.clubName}',
+      if (p.primaryEvents != null) 'Events: ${p.primaryEvents}',
+      'Pool length: ${p.preferredPoolLengthMeters} m',
+      if (p.preferredStrokes.isNotEmpty)
+        'Preferred strokes: ${p.preferredStrokes.join(', ')}',
+    ];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: rows.map((r) => Text(r)).toList(),
+    );
+  }
+}
+
+class _SwimSessionsBody extends StatelessWidget {
+  const _SwimSessionsBody({required this.sessions});
+
+  final List<dynamic>? sessions;
+
+  @override
+  Widget build(BuildContext context) {
+    if (sessions == null || sessions!.isEmpty) {
+      return const Text('No data');
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: sessions!
+          .map<Widget>(
+              (s) => Text('${s.date} — ${s.stroke} ${s.totalDistance} m'))
+          .toList(),
+    );
+  }
+}
+
+class _RaceTimesBody extends StatelessWidget {
+  const _RaceTimesBody({required this.raceTimes});
+
+  final List<dynamic>? raceTimes;
+
+  @override
+  Widget build(BuildContext context) {
+    if (raceTimes == null || raceTimes!.isEmpty) {
+      return const Text('No data');
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: raceTimes!
+          .map<Widget>((r) => Text('${r.raceName} — ${r.distance} m'))
+          .toList(),
+    );
+  }
+}
+
+class _PersonalBestsBody extends StatelessWidget {
+  const _PersonalBestsBody({required this.pbs});
+
+  final List<dynamic>? pbs;
+
+  @override
+  Widget build(BuildContext context) {
+    if (pbs == null || pbs!.isEmpty) {
+      return const Text('No data');
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: pbs!
+          .map<Widget>((pb) => Text('${pb.stroke} ${pb.distance} m'))
+          .toList(),
+    );
+  }
+}
+
+class _DrylandBody extends StatelessWidget {
+  const _DrylandBody({required this.workouts});
+
+  final List<dynamic>? workouts;
+
+  @override
+  Widget build(BuildContext context) {
+    if (workouts == null || workouts!.isEmpty) {
+      return const Text('No data');
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: workouts!
+          .map<Widget>(
+              (w) => Text('${w.date} — ${w.exercises.length} exercise(s)'))
+          .toList(),
+    );
+  }
+}
+
+class _AnalyticsBody extends StatelessWidget {
+  const _AnalyticsBody({required this.analytics});
+
+  final dynamic analytics;
+
+  @override
+  Widget build(BuildContext context) {
+    if (analytics == null) {
+      return const Text('No data');
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Total sessions: ${analytics.totalSessions}'),
+        Text('Total distance: ${analytics.totalDistanceMeters} m'),
+        Text('Consistency score: ${analytics.consistencyScore}'),
+      ],
+    );
+  }
+}

--- a/lib/features/coach/presentation/screens/coach_view_screen.dart
+++ b/lib/features/coach/presentation/screens/coach_view_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:printing/printing.dart';
 
+import '../../../profiles/presentation/providers/profile_providers.dart';
 import '../../domain/entities/coach_report.dart';
 import '../../domain/entities/coach_share_category.dart';
 import '../../domain/services/coach_pdf_builder.dart';
@@ -60,14 +61,19 @@ class _CoachViewScreenState extends ConsumerState<CoachViewScreen> {
           return _reportScaffold(context, selected);
         }
 
+        final profilesAsync = ref.watch(profilesProvider);
+        final profiles = profilesAsync.valueOrNull ?? const [];
+
         return Scaffold(
           appBar: _buildAppBar(context, null),
           body: ListView.builder(
             itemCount: ids.length,
             itemBuilder: (context, index) {
               final id = ids[index];
+              final match = profiles.where((p) => p.id == id);
+              final label = match.isNotEmpty ? match.first.displayName : id;
               return ListTile(
-                title: Text(id),
+                title: Text(label),
                 onTap: () => setState(() => _selectedProfileId = id),
               );
             },
@@ -128,11 +134,19 @@ class _CoachViewScreenState extends ConsumerState<CoachViewScreen> {
   // ---------------------------------------------------------------------------
 
   Future<void> _exportPdf(CoachReport report) async {
-    final Uint8List bytes = await const CoachPdfBuilder().build(report);
-    await Printing.sharePdf(
-      bytes: bytes,
-      filename: '${report.profile.displayName}_coach_report.pdf',
-    );
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final Uint8List bytes = await const CoachPdfBuilder().build(report);
+      if (!context.mounted) return;
+      await Printing.sharePdf(
+        bytes: bytes,
+        filename: '${report.profile.displayName}_coach_report.pdf',
+      );
+    } catch (_) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Could not export PDF')),
+      );
+    }
   }
 }
 

--- a/lib/features/profiles/presentation/screens/profiles_screen.dart
+++ b/lib/features/profiles/presentation/screens/profiles_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../../core/constants/app_constants.dart';
+import '../../../coach/presentation/providers/coach_providers.dart';
 import '../../domain/entities/swimmer_profile.dart';
 import '../../domain/services/profile_details_service.dart';
 import '../providers/profile_providers.dart';
@@ -111,9 +113,21 @@ class ProfilesScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final profilesAsync = ref.watch(profilesProvider);
     final currentProfileId = ref.watch(currentProfileIdProvider);
+    final sharedIds =
+        ref.watch(sharedProfileIdsProvider).valueOrNull ?? const [];
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Swimmer Profiles')),
+      appBar: AppBar(
+        title: const Text('Swimmer Profiles'),
+        actions: [
+          if (sharedIds.isNotEmpty)
+            IconButton(
+              icon: const Icon(Icons.supervisor_account_outlined),
+              tooltip: 'Coach view',
+              onPressed: () => context.push('/coach'),
+            ),
+        ],
+      ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () => _showProfileDialog(context, ref),
         icon: const Icon(Icons.add),
@@ -131,9 +145,11 @@ class ProfilesScreen extends ConsumerWidget {
             itemBuilder: (context, index) {
               final profile = profiles[index];
               final isCurrent = profile.id == currentProfileId;
+              final isShared = sharedIds.contains(profile.id);
               return _ProfileTile(
                 profile: profile,
                 isCurrent: isCurrent,
+                isSharedWithCoach: isShared,
                 onSelect: () {
                   ref.read(selectedProfileIdProvider.notifier).state =
                       profile.id;
@@ -144,6 +160,8 @@ class ProfilesScreen extends ConsumerWidget {
                   profile: profile,
                 ),
                 onArchive: () => _archiveProfile(context, ref, profile),
+                onCoachSharing: () =>
+                    context.push('/coach/sharing/${profile.id}'),
               );
             },
           );
@@ -160,16 +178,20 @@ class _ProfileTile extends StatelessWidget {
   const _ProfileTile({
     required this.profile,
     required this.isCurrent,
+    required this.isSharedWithCoach,
     required this.onSelect,
     required this.onEdit,
     required this.onArchive,
+    required this.onCoachSharing,
   });
 
   final SwimmerProfile profile;
   final bool isCurrent;
+  final bool isSharedWithCoach;
   final VoidCallback onSelect;
   final VoidCallback onEdit;
   final VoidCallback onArchive;
+  final VoidCallback onCoachSharing;
 
   @override
   Widget build(BuildContext context) {
@@ -232,11 +254,36 @@ class _ProfileTile extends StatelessWidget {
                         ),
                   ),
                 ),
+                if (isSharedWithCoach) ...[
+                  const SizedBox(height: 4),
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.supervisor_account_outlined,
+                        size: 14,
+                        color: colorScheme.primary,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        'Shared with coach',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: colorScheme.primary,
+                            ),
+                      ),
+                    ],
+                  ),
+                ],
               ],
             ),
             trailing: Wrap(
               spacing: 4,
               children: [
+                IconButton(
+                  icon: const Icon(Icons.supervisor_account_outlined),
+                  tooltip: 'Coach sharing',
+                  onPressed: onCoachSharing,
+                ),
                 IconButton(
                   icon: const Icon(Icons.edit_outlined),
                   tooltip: 'Edit swimmer',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,8 @@ dependencies:
   fl_chart: ^0.68.0
   intl: ^0.19.0
   path: ^1.9.0
+  pdf: ^3.11.0
+  printing: ^5.13.0
 
 dev_dependencies:
   flutter_test:

--- a/test/database/coach_share_dao_test.dart
+++ b/test/database/coach_share_dao_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/core/constants/app_constants.dart';
 import 'package:rep_swim/database/app_database.dart';
 import 'package:rep_swim/database/daos/coach_share_dao.dart';
 import 'package:rep_swim/features/coach/domain/entities/coach_share.dart';
@@ -77,5 +78,45 @@ void main() {
     });
     final loaded = await dao.getForProfile('local-default-profile');
     expect(loaded.sharedCategories, {CoachShareCategory.goals});
+  });
+
+  test(
+      'deleting a swimmer_profile cascades to coach_shares via ON DELETE CASCADE',
+      () async {
+    // Save an enabled CoachShare for the default profile.
+    await dao.save(const CoachShare(
+      profileId: kDefaultProfileId,
+      enabled: true,
+      sharedCategories: {CoachShareCategory.goals},
+    ));
+
+    // Confirm the row exists before deletion.
+    final database = await db.database;
+    final beforeRows = await database.query(
+      'coach_shares',
+      where: 'profile_id = ?',
+      whereArgs: [kDefaultProfileId],
+    );
+    expect(beforeRows, hasLength(1));
+
+    // Delete the profile row directly to trigger ON DELETE CASCADE.
+    await database.delete(
+      'swimmer_profiles',
+      where: 'id = ?',
+      whereArgs: [kDefaultProfileId],
+    );
+
+    // The coach_shares row must be gone.
+    final afterRows = await database.query(
+      'coach_shares',
+      where: 'profile_id = ?',
+      whereArgs: [kDefaultProfileId],
+    );
+    expect(afterRows, isEmpty);
+
+    // The DAO must return the disabled default (no row).
+    final share = await dao.getForProfile(kDefaultProfileId);
+    expect(share.enabled, isFalse);
+    expect(share.sharedCategories, isEmpty);
   });
 }

--- a/test/database/coach_share_dao_test.dart
+++ b/test/database/coach_share_dao_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/database/app_database.dart';
+import 'package:rep_swim/database/daos/coach_share_dao.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share_category.dart';
+
+void main() {
+  late AppDatabase db;
+  late CoachShareDao dao;
+
+  setUp(() {
+    db = AppDatabase.test();
+    dao = CoachShareDao(db);
+  });
+
+  tearDown(() => db.close());
+
+  test('getForProfile returns a disabled default when no row exists', () async {
+    final share = await dao.getForProfile('local-default-profile');
+    expect(share.profileId, 'local-default-profile');
+    expect(share.enabled, isFalse);
+    expect(share.sharedCategories, isEmpty);
+  });
+
+  test('save then getForProfile round-trips enabled state and categories',
+      () async {
+    const share = CoachShare(
+      profileId: 'local-default-profile',
+      enabled: true,
+      sharedCategories: {
+        CoachShareCategory.goals,
+        CoachShareCategory.swimSessions,
+      },
+    );
+    await dao.save(share);
+
+    final loaded = await dao.getForProfile('local-default-profile');
+    expect(loaded.enabled, isTrue);
+    expect(loaded.sharedCategories, {
+      CoachShareCategory.goals,
+      CoachShareCategory.swimSessions,
+    });
+  });
+
+  test('save overwrites a previous configuration', () async {
+    await dao.save(const CoachShare(
+      profileId: 'local-default-profile',
+      enabled: true,
+      sharedCategories: {CoachShareCategory.notes},
+    ));
+    await dao.save(const CoachShare(
+      profileId: 'local-default-profile',
+      enabled: false,
+    ));
+    final loaded = await dao.getForProfile('local-default-profile');
+    expect(loaded.enabled, isFalse);
+    expect(loaded.sharedCategories, isEmpty);
+  });
+
+  test('getSharedProfileIds lists only profiles with active sharing', () async {
+    await dao.save(const CoachShare(
+      profileId: 'local-default-profile',
+      enabled: true,
+      sharedCategories: {CoachShareCategory.goals},
+    ));
+    final ids = await dao.getSharedProfileIds();
+    expect(ids, contains('local-default-profile'));
+  });
+
+  test('unknown category keys in storage are ignored on read', () async {
+    final database = await db.database;
+    await database.insert('coach_shares', {
+      'profile_id': 'local-default-profile',
+      'enabled': 1,
+      'shared_categories_json': '["goals","bogus_category"]',
+      'updated_at': DateTime.now().millisecondsSinceEpoch,
+    });
+    final loaded = await dao.getForProfile('local-default-profile');
+    expect(loaded.sharedCategories, {CoachShareCategory.goals});
+  });
+}

--- a/test/database/coach_shares_migration_test.dart
+++ b/test/database/coach_shares_migration_test.dart
@@ -13,12 +13,14 @@ void main() {
 
     final columns = await database.rawQuery('PRAGMA table_info(coach_shares)');
     final names = columns.map((row) => row['name'] as String).toSet();
-    expect(names, containsAll(<String>[
-      'profile_id',
-      'enabled',
-      'shared_categories_json',
-      'updated_at',
-    ]));
+    expect(
+        names,
+        containsAll(<String>[
+          'profile_id',
+          'enabled',
+          'shared_categories_json',
+          'updated_at',
+        ]));
 
     await db.close();
   });

--- a/test/database/coach_shares_migration_test.dart
+++ b/test/database/coach_shares_migration_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/database/app_database.dart';
+
+void main() {
+  test('coach_shares table exists with the expected columns', () async {
+    final db = AppDatabase.test();
+    final database = await db.database;
+
+    final tables = await database.rawQuery(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='coach_shares'",
+    );
+    expect(tables, hasLength(1), reason: 'coach_shares table must exist');
+
+    final columns = await database.rawQuery('PRAGMA table_info(coach_shares)');
+    final names = columns.map((row) => row['name'] as String).toSet();
+    expect(names, containsAll(<String>[
+      'profile_id',
+      'enabled',
+      'shared_categories_json',
+      'updated_at',
+    ]));
+
+    await db.close();
+  });
+}

--- a/test/database/migration_test.dart
+++ b/test/database/migration_test.dart
@@ -11,7 +11,7 @@ void main() {
   });
 
   group('database migrations', () {
-    for (final oldVersion in [1, 3, 4, 5, 7, 8, 9, 10, 11]) {
+    for (final oldVersion in [1, 3, 4, 5, 7, 8, 9, 10, 11, 12]) {
       test('upgrades version $oldVersion to current schema', () async {
         final path = p.join(
           Directory.systemTemp.path,
@@ -40,6 +40,7 @@ void main() {
         expect(await _hasTable(db, 'meet_qualification_standards'), isTrue);
         expect(await _hasTable(db, 'tempo_templates'), isTrue);
         expect(await _hasTable(db, 'tempo_session_results'), isTrue);
+        expect(await _hasTable(db, 'coach_shares'), isTrue);
         expect(await _hasColumn(db, 'swimmer_profiles', 'photo_uri'), isTrue);
         expect(
           await _hasColumn(db, 'swimmer_profiles', 'preferred_strokes_json'),
@@ -274,6 +275,47 @@ Future<void> _createOldSchema(Database db, int version) async {
         valid_from INTEGER NOT NULL,
         competition_start INTEGER NOT NULL,
         competition_end INTEGER NOT NULL
+      )
+    ''');
+  }
+  if (version >= 12) {
+    await db.execute('''
+      CREATE TABLE tempo_templates (
+        id TEXT PRIMARY KEY,
+        profile_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        mode TEXT NOT NULL,
+        pool_length_meters INTEGER NOT NULL,
+        target_distance_meters INTEGER NOT NULL,
+        target_time_milliseconds INTEGER NOT NULL,
+        stroke_rate REAL NOT NULL,
+        breath_every_strokes INTEGER NOT NULL,
+        audible_enabled INTEGER NOT NULL,
+        vibration_enabled INTEGER NOT NULL,
+        visual_flash_enabled INTEGER NOT NULL,
+        spoken_enabled INTEGER NOT NULL,
+        accent_every INTEGER NOT NULL,
+        safety_warning_acknowledged INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    ''');
+    await db.execute('''
+      CREATE TABLE tempo_session_results (
+        id TEXT PRIMARY KEY,
+        profile_id TEXT NOT NULL,
+        template_id TEXT,
+        mode TEXT NOT NULL,
+        started_at INTEGER NOT NULL,
+        completed_at INTEGER,
+        target_distance_meters INTEGER NOT NULL,
+        pool_length_meters INTEGER NOT NULL,
+        target_time_milliseconds INTEGER NOT NULL,
+        target_stroke_rate REAL NOT NULL,
+        actual_splits_milliseconds_json TEXT NOT NULL,
+        stroke_counts_json TEXT NOT NULL,
+        rpe INTEGER,
+        notes TEXT
       )
     ''');
   }

--- a/test/features/coach/domain/coach_pdf_builder_test.dart
+++ b/test/features/coach/domain/coach_pdf_builder_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_report.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share_category.dart';
+import 'package:rep_swim/features/coach/domain/services/coach_pdf_builder.dart';
+import 'package:rep_swim/features/profiles/domain/entities/swimmer_profile.dart';
+
+void main() {
+  test('builds a non-empty PDF for a report', () async {
+    final report = CoachReport(
+      profile: SwimmerProfile.defaultProfile,
+      includedCategories: const {CoachShareCategory.profileDetails},
+    );
+    final bytes = await const CoachPdfBuilder().build(report);
+    expect(bytes, isNotEmpty);
+    // A PDF file starts with the "%PDF" magic bytes.
+    expect(String.fromCharCodes(bytes.take(4)), '%PDF');
+  });
+}

--- a/test/features/coach/domain/coach_report_builder_test.dart
+++ b/test/features/coach/domain/coach_report_builder_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/database/app_database.dart';
+import 'package:rep_swim/database/daos/dryland_dao.dart';
+import 'package:rep_swim/database/daos/pb_dao.dart';
+import 'package:rep_swim/database/daos/profile_dao.dart';
+import 'package:rep_swim/database/daos/race_time_dao.dart';
+import 'package:rep_swim/database/daos/swim_session_dao.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share_category.dart';
+import 'package:rep_swim/features/coach/domain/services/coach_report_builder.dart';
+import 'package:rep_swim/features/profiles/domain/entities/swimmer_profile.dart';
+import 'package:rep_swim/features/race/domain/entities/race_time.dart';
+import 'package:rep_swim/features/swim/domain/entities/swim_session.dart';
+
+void main() {
+  late AppDatabase db;
+  late ProfileDao profileDao;
+  late SwimSessionDao sessionDao;
+  late RaceTimeDao raceTimeDao;
+  late PbDao pbDao;
+  late DrylandDao drylandDao;
+  late CoachReportBuilder builder;
+
+  setUp(() async {
+    db = AppDatabase.test();
+    profileDao = ProfileDao(db);
+    sessionDao = SwimSessionDao(db);
+    raceTimeDao = RaceTimeDao(db);
+    pbDao = PbDao(db);
+    drylandDao = DrylandDao(db);
+    builder = CoachReportBuilder(
+      profileDao: profileDao,
+      sessionDao: sessionDao,
+      raceTimeDao: raceTimeDao,
+      pbDao: pbDao,
+      drylandDao: drylandDao,
+    );
+
+    // Seed profile p1.
+    final now = DateTime.utc(2025, 1, 1);
+    await profileDao.insert(SwimmerProfile(
+      id: 'p1',
+      displayName: 'Alice',
+      createdAt: now,
+      updatedAt: now,
+    ));
+
+    // Seed profile p2.
+    await profileDao.insert(SwimmerProfile(
+      id: 'p2',
+      displayName: 'Bob',
+      createdAt: now,
+      updatedAt: now,
+    ));
+
+    // Swim session for p1.
+    await sessionDao.insertSession(SwimSession(
+      id: 's1',
+      profileId: 'p1',
+      date: DateTime.utc(2025, 1, 1),
+      totalDistance: 1000,
+      totalTime: const Duration(minutes: 20),
+      stroke: 'freestyle',
+      laps: const [],
+    ));
+
+    // Swim session for p2.
+    await sessionDao.insertSession(SwimSession(
+      id: 's2',
+      profileId: 'p2',
+      date: DateTime.utc(2025, 1, 2),
+      totalDistance: 500,
+      totalTime: const Duration(minutes: 10),
+      stroke: 'backstroke',
+      laps: const [],
+    ));
+
+    // Race time for p1.
+    final ts = DateTime.utc(2025, 1, 1);
+    await raceTimeDao.insertOrUpdate(RaceTime(
+      id: 'r1',
+      profileId: 'p1',
+      raceName: 'Club Champs',
+      eventDate: ts,
+      distance: 100,
+      stroke: 'freestyle',
+      course: RaceCourse.shortCourseMeters,
+      time: const Duration(seconds: 60),
+      createdAt: ts,
+      updatedAt: ts,
+    ));
+  });
+
+  tearDown(() => db.close());
+
+  test('only shared categories are loaded', () async {
+    const share = CoachShare(
+      profileId: 'p1',
+      enabled: true,
+      sharedCategories: {CoachShareCategory.swimSessions},
+    );
+
+    final report = await builder.build('p1', share);
+
+    expect(report.includes(CoachShareCategory.swimSessions), isTrue);
+    expect(report.swimSessions, isNotNull);
+    expect(report.includes(CoachShareCategory.raceTimes), isFalse);
+    expect(report.raceTimes, isNull);
+    expect(report.includes(CoachShareCategory.personalBests), isFalse);
+    expect(report.personalBests, isNull);
+    expect(report.includes(CoachShareCategory.dryland), isFalse);
+    expect(report.drylandWorkouts, isNull);
+    expect(report.includes(CoachShareCategory.analytics), isFalse);
+    expect(report.analytics, isNull);
+  });
+
+  test('report is scoped to the requested profile', () async {
+    const share = CoachShare(
+      profileId: 'p1',
+      enabled: true,
+      sharedCategories: {CoachShareCategory.swimSessions},
+    );
+
+    final report = await builder.build('p1', share);
+
+    expect(report.swimSessions, isNotNull);
+    for (final session in report.swimSessions!) {
+      expect(session.profileId, 'p1');
+    }
+  });
+}

--- a/test/features/coach/domain/coach_report_test.dart
+++ b/test/features/coach/domain/coach_report_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_report.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share_category.dart';
+import 'package:rep_swim/features/profiles/domain/entities/swimmer_profile.dart';
+
+void main() {
+  test('a report exposes exactly the categories it was built with', () {
+    final report = CoachReport(
+      profile: SwimmerProfile.defaultProfile,
+      includedCategories: const {
+        CoachShareCategory.goals,
+        CoachShareCategory.swimSessions,
+      },
+      swimSessions: const [],
+    );
+    expect(report.includes(CoachShareCategory.goals), isTrue);
+    expect(report.includes(CoachShareCategory.notes), isFalse);
+  });
+}

--- a/test/features/coach/domain/coach_share_category_test.dart
+++ b/test/features/coach/domain/coach_share_category_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share_category.dart';
+
+void main() {
+  group('CoachShareCategory', () {
+    test('exposes eight categories', () {
+      expect(CoachShareCategory.values.length, 8);
+    });
+
+    test('every category has a unique non-empty key and label', () {
+      final keys = CoachShareCategory.values.map((c) => c.key).toSet();
+      expect(keys.length, 8);
+      for (final c in CoachShareCategory.values) {
+        expect(c.key, isNotEmpty);
+        expect(c.label, isNotEmpty);
+      }
+    });
+
+    test('fromKey round-trips every category', () {
+      for (final c in CoachShareCategory.values) {
+        expect(CoachShareCategory.fromKey(c.key), c);
+      }
+    });
+
+    test('fromKey returns null for an unknown key', () {
+      expect(CoachShareCategory.fromKey('not_a_category'), isNull);
+    });
+  });
+}

--- a/test/features/coach/domain/coach_share_test.dart
+++ b/test/features/coach/domain/coach_share_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share_category.dart';
+
+void main() {
+  group('CoachShare', () {
+    test('a profile with no row is not sharing anything', () {
+      const share = CoachShare(profileId: 'p1');
+      expect(share.enabled, isFalse);
+      expect(share.hasActiveSharing, isFalse);
+      expect(share.isShared(CoachShareCategory.goals), isFalse);
+    });
+
+    test('isShared requires both the master flag and the category', () {
+      const disabled = CoachShare(
+        profileId: 'p1',
+        sharedCategories: {CoachShareCategory.goals},
+      );
+      expect(disabled.isShared(CoachShareCategory.goals), isFalse,
+          reason: 'master flag off means nothing is shared');
+
+      const enabled = CoachShare(
+        profileId: 'p1',
+        enabled: true,
+        sharedCategories: {CoachShareCategory.goals},
+      );
+      expect(enabled.isShared(CoachShareCategory.goals), isTrue);
+      expect(enabled.isShared(CoachShareCategory.notes), isFalse);
+    });
+
+    test('withCategory and withoutCategory return updated copies', () {
+      const base = CoachShare(profileId: 'p1', enabled: true);
+      final added = base.withCategory(CoachShareCategory.notes);
+      expect(added.sharedCategories, {CoachShareCategory.notes});
+      expect(base.sharedCategories, isEmpty, reason: 'original unchanged');
+
+      final removed = added.withoutCategory(CoachShareCategory.notes);
+      expect(removed.sharedCategories, isEmpty);
+    });
+
+    test('activeCategories is empty when the master flag is off', () {
+      const share = CoachShare(
+        profileId: 'p1',
+        sharedCategories: {CoachShareCategory.goals},
+      );
+      expect(share.activeCategories, isEmpty);
+    });
+
+    test('hasActiveSharing is true only when enabled with a category', () {
+      const enabledNoCategories = CoachShare(profileId: 'p1', enabled: true);
+      expect(enabledNoCategories.hasActiveSharing, isFalse);
+
+      const enabledWithCategory = CoachShare(
+        profileId: 'p1',
+        enabled: true,
+        sharedCategories: {CoachShareCategory.dryland},
+      );
+      expect(enabledWithCategory.hasActiveSharing, isTrue);
+    });
+  });
+}

--- a/test/features/coach/presentation/coach_providers_test.dart
+++ b/test/features/coach/presentation/coach_providers_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/core/constants/app_constants.dart';
+import 'package:rep_swim/database/app_database.dart';
+import 'package:rep_swim/database/daos/coach_share_dao.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share_category.dart';
+import 'package:rep_swim/features/coach/presentation/providers/coach_providers.dart';
+
+void main() {
+  test('CoachShareController loads, toggles, and persists a profile share',
+      () async {
+    final db = AppDatabase.test();
+    addTearDown(db.close);
+    final dao = CoachShareDao(db);
+
+    final container = ProviderContainer(overrides: [
+      coachShareDaoProvider.overrideWithValue(dao),
+    ]);
+    addTearDown(container.dispose);
+
+    final controller = container
+        .read(coachShareControllerProvider(kDefaultProfileId).notifier);
+    await controller.future;
+
+    await controller.setEnabled(true);
+    await controller.setCategory(CoachShareCategory.goals, true);
+
+    final reloaded = await dao.getForProfile(kDefaultProfileId);
+    expect(reloaded.enabled, isTrue);
+    expect(reloaded.isShared(CoachShareCategory.goals), isTrue);
+  });
+
+  test('stopSharing disables sharing for the profile', () async {
+    final db = AppDatabase.test();
+    addTearDown(db.close);
+    final dao = CoachShareDao(db);
+    await dao.save(const CoachShare(
+      profileId: kDefaultProfileId,
+      enabled: true,
+      sharedCategories: {CoachShareCategory.notes},
+    ));
+
+    final container = ProviderContainer(overrides: [
+      coachShareDaoProvider.overrideWithValue(dao),
+    ]);
+    addTearDown(container.dispose);
+
+    final controller = container
+        .read(coachShareControllerProvider(kDefaultProfileId).notifier);
+    await controller.future;
+    await controller.stopSharing();
+
+    expect((await dao.getForProfile(kDefaultProfileId)).enabled, isFalse);
+  });
+}

--- a/test/features/coach/presentation/coach_sharing_settings_screen_test.dart
+++ b/test/features/coach/presentation/coach_sharing_settings_screen_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/core/constants/app_constants.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share_category.dart';
+import 'package:rep_swim/features/coach/presentation/providers/coach_providers.dart';
+import 'package:rep_swim/features/coach/presentation/screens/coach_sharing_settings_screen.dart';
+
+/// A fake [CoachShareController] backed by an in-memory store so widget tests
+/// don't need real SQLite I/O and [WidgetTester.pumpAndSettle] doesn't time out.
+class _FakeCoachShareController extends CoachShareController {
+  _FakeCoachShareController(CoachShare initial) {
+    _store = initial;
+  }
+
+  late CoachShare _store;
+
+  // Expose the current share so tests can inspect state after interactions.
+  CoachShare get current => _store;
+
+  @override
+  Future<CoachShare> build(String profileId) async => _store;
+
+  @override
+  Future<void> setEnabled(bool enabled) async {
+    _store = _store.copyWith(enabled: enabled);
+    state = AsyncData(_store);
+  }
+
+  @override
+  Future<void> setCategory(CoachShareCategory category, bool shared) async {
+    _store = shared
+        ? _store.withCategory(category)
+        : _store.withoutCategory(category);
+    state = AsyncData(_store);
+  }
+
+  @override
+  Future<void> stopSharing() async {
+    _store = _store.copyWith(enabled: false);
+    state = AsyncData(_store);
+  }
+}
+
+void main() {
+  testWidgets('enabling sharing reveals the category toggles', (tester) async {
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        coachShareControllerProvider.overrideWith(
+          () => _FakeCoachShareController(
+            const CoachShare(profileId: kDefaultProfileId),
+          ),
+        ),
+      ],
+      child: const MaterialApp(
+        home: CoachSharingSettingsScreen(profileId: kDefaultProfileId),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Goals'), findsNothing);
+    await tester.tap(find.byType(SwitchListTile).first);
+    await tester.pumpAndSettle();
+    expect(find.text('Goals'), findsOneWidget);
+  });
+
+  testWidgets('Stop sharing turns the master switch off', (tester) async {
+    late _FakeCoachShareController controller;
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        coachShareControllerProvider.overrideWith(() {
+          controller = _FakeCoachShareController(
+            const CoachShare(
+              profileId: kDefaultProfileId,
+              enabled: true,
+              sharedCategories: {CoachShareCategory.goals},
+            ),
+          );
+          return controller;
+        }),
+      ],
+      child: const MaterialApp(
+        home: CoachSharingSettingsScreen(profileId: kDefaultProfileId),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.dragUntilVisible(
+      find.text('Stop sharing'),
+      find.byType(ListView),
+      const Offset(0, -200),
+    );
+    await tester.tap(find.text('Stop sharing'));
+    await tester.pumpAndSettle();
+
+    expect(controller.current.enabled, isFalse);
+  });
+}

--- a/test/features/coach/presentation/coach_view_screen_test.dart
+++ b/test/features/coach/presentation/coach_view_screen_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_report.dart';
+import 'package:rep_swim/features/coach/domain/entities/coach_share_category.dart';
+import 'package:rep_swim/features/coach/presentation/providers/coach_providers.dart';
+import 'package:rep_swim/features/coach/presentation/providers/coach_report_providers.dart';
+import 'package:rep_swim/features/coach/presentation/screens/coach_view_screen.dart';
+import 'package:rep_swim/features/profiles/domain/entities/swimmer_profile.dart';
+
+void main() {
+  const someProfileId = 'test-profile-001';
+
+  final fixedProfile = SwimmerProfile(
+    id: someProfileId,
+    displayName: 'Test Swimmer',
+    createdAt: DateTime(2024),
+    updatedAt: DateTime(2024),
+  );
+
+  final fixedReport = CoachReport(
+    profile: fixedProfile,
+    includedCategories: const {CoachShareCategory.swimSessions},
+    swimSessions: const [],
+    raceTimes: null,
+  );
+
+  testWidgets('shows swim sessions panel when included in report',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedProfileIdsProvider.overrideWith(
+            (ref) async => [someProfileId],
+          ),
+          coachReportProvider(someProfileId).overrideWith(
+            (ref) async => fixedReport,
+          ),
+        ],
+        child: const MaterialApp(
+          home: CoachViewScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Swim sessions'), findsOneWidget);
+  });
+
+  testWidgets('does not show race times panel when not in report',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedProfileIdsProvider.overrideWith(
+            (ref) async => [someProfileId],
+          ),
+          coachReportProvider(someProfileId).overrideWith(
+            (ref) async => fixedReport,
+          ),
+        ],
+        child: const MaterialApp(
+          home: CoachViewScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Race times'), findsNothing);
+  });
+
+  testWidgets('shows no edit or delete icons (read-only screen)',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedProfileIdsProvider.overrideWith(
+            (ref) async => [someProfileId],
+          ),
+          coachReportProvider(someProfileId).overrideWith(
+            (ref) async => fixedReport,
+          ),
+        ],
+        child: const MaterialApp(
+          home: CoachViewScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.edit), findsNothing);
+    expect(find.byIcon(Icons.delete), findsNothing);
+  });
+
+  testWidgets('shows message when no profiles are shared', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedProfileIdsProvider.overrideWith(
+            (ref) async => <String>[],
+          ),
+        ],
+        child: const MaterialApp(
+          home: CoachViewScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('No profiles are shared with a coach'), findsOneWidget);
+  });
+}

--- a/test/features/profiles/profiles_screen_coach_test.dart
+++ b/test/features/profiles/profiles_screen_coach_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rep_swim/core/constants/app_constants.dart';
+import 'package:rep_swim/features/coach/presentation/providers/coach_providers.dart';
+import 'package:rep_swim/features/profiles/domain/entities/swimmer_profile.dart';
+import 'package:rep_swim/features/profiles/presentation/providers/profile_providers.dart';
+import 'package:rep_swim/features/profiles/presentation/providers/profile_summary_providers.dart';
+import 'package:rep_swim/features/profiles/presentation/screens/profiles_screen.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:rep_swim/database/daos/profile_dao.dart';
+
+class _NoopProfileDao extends Mock implements ProfileDao {}
+
+class _FixedProfilesNotifier extends ProfilesNotifier {
+  _FixedProfilesNotifier(List<SwimmerProfile> profiles)
+      : super(_NoopProfileDao()) {
+    state = AsyncValue.data(profiles);
+  }
+
+  @override
+  Future<void> load() async {}
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required List<SwimmerProfile> profiles,
+  required List<String> sharedIds,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        profilesProvider.overrideWith(
+          (ref) => _FixedProfilesNotifier(profiles),
+        ),
+        profileSummaryProvider.overrideWith(
+          (ref, profileId) async => const ProfileSummary(
+            sessionCount: 0,
+            totalDistance: 0,
+            drylandWorkoutCount: 0,
+            personalBestCount: 0,
+          ),
+        ),
+        sharedProfileIdsProvider.overrideWith(
+          (ref) async => sharedIds,
+        ),
+      ],
+      child: const MaterialApp(home: ProfilesScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets(
+    'shows Shared with coach badge when profile id is in sharedProfileIdsProvider',
+    (tester) async {
+      await _pump(
+        tester,
+        profiles: [SwimmerProfile.defaultProfile],
+        sharedIds: [kDefaultProfileId],
+      );
+
+      expect(find.text('Shared with coach'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'does not show Shared with coach badge when sharedProfileIdsProvider is empty',
+    (tester) async {
+      await _pump(
+        tester,
+        profiles: [SwimmerProfile.defaultProfile],
+        sharedIds: [],
+      );
+
+      expect(find.text('Shared with coach'), findsNothing);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Adds **coach mode** (issue #10) — a swimmer can share selected profiles and data categories with a coach in a controlled, read-only way.

- **Per-profile, per-category opt-in sharing**, persisted in a new `coach_shares` table (schema v13). Eight categories: profile details, goals, notes, swim sessions, race times, personal bests, analytics, dryland. All default off.
- **Sealed on-device coach view** — a read-only screen, outside the app shell, with no edit/add/delete affordances. Shows only shared categories.
- **PDF export** of a shared profile's data via the new `pdf`/`printing` dependencies.
- A single `CoachReportBuilder` assembles the shared data once; the coach view and the PDF builder both consume it, so they cannot diverge. The report builder is profile-scoped — it never loads an unshared category or another profile's data.
- **Sharing surfaced on the Profiles screen** — a "Coach sharing" action and a "Shared with coach" badge per profile, plus a "Coach view" entry. Sharing is revocable.

## Architecture

New `lib/features/coach/` module (domain/data/presentation) + `CoachShareDao`. Built test-first across 14 tasks.

## Test plan

- [x] `flutter test` — 213/213 pass (unit, widget, and integration tests for sharing rules, profile scoping, persistence, the v12→v13 migration including cascade delete, the settings screen, and the sealed coach view).
- [x] `flutter analyze` — clean.
- [ ] Reviewer: exercise the coach view and PDF export on a device/emulator.

## Follow-ups (not blocking)

- `AnalyticsData` / `computeAnalytics` live in the analytics *presentation* layer; the coach domain now imports them. Pre-existing layering issue — worth a separate ticket to move them to `analytics/domain/`.
- The coach view's private body widgets use `dynamic`-typed lists internally; could be tightened to concrete types.

Closes #10
